### PR TITLE
Reduce memory consumption - det extraction

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -3306,8 +3306,9 @@ def extract_from_stream(stream, detections, pad=2.0, length=30.0):
                 print('No data in stream for pick:')
                 print(pick)
                 continue
-            cut_stream += tr.copy().trim(starttime=pick.time - pad,
-                                         endtime=pick.time - pad + length)
+            cut_stream += tr.slice(
+                starttime=pick.time - pad,
+                endtime=pick.time - pad + length).copy()
         streams.append(cut_stream)
     return streams
 


### PR DESCRIPTION
Issue noted by user with low memory machine - crashes when extracting detection streams from the continuous data.  Suggest change from copying long data and trimming the copy, to slicing the continuous data and then copying the slice - this *should* reduce memory consumption.