### PR TITLE
Debug failing lag_calc test

### DIFF
--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -233,6 +233,8 @@ class ShortTests(unittest.TestCase):
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
             _xcorr_interp(ccc, 0.1)
+        for _w in w:
+            print(_w.message)
         self.assertEqual(len(w), 2)
         self.assertTrue('Less than 5 samples' in str(w[0].message))
         self.assertTrue('Residual in quadratic fit' in str(w[1].message))

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -17,6 +17,8 @@ from eqcorrscan.core.template_gen import from_sfile
 from eqcorrscan.core.match_filter import normxcorr2, Detection
 from eqcorrscan.utils.sfile_util import read_event
 
+warnings.simplefilter("always")
+
 
 class TestMethods(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
For some reason test_bad_interp only raises one warning on travis, but two locally - attempt to debug