### PR TITLE
Append streams when return_stream == True

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2447,7 +2447,8 @@ class Tribe(object):
                     parallel_process=parallel_process,
                     ignore_length=ignore_length, group_size=group_size,
                     debug=debug)
-                stream += st
+                if return_stream:
+                    stream += st
             except Exception as e:
                 print('Error, routine incomplete, returning incomplete Party')
                 print('Error: %s' % str(e))

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2426,6 +2426,8 @@ class Tribe(object):
                     chan_id += ('*', )
                 template_channel_ids.append(chan_id)
         template_channel_ids = list(set(template_channel_ids))
+        if return_stream:
+            stream = Stream()
         for i in range(int(download_groups + 1)):
             bulk_info = []
             for chan_id in template_channel_ids:
@@ -2445,6 +2447,7 @@ class Tribe(object):
                     parallel_process=parallel_process,
                     ignore_length=ignore_length, group_size=group_size,
                     debug=debug)
+                stream += st
             except Exception as e:
                 print('Error, routine incomplete, returning incomplete Party')
                 print('Error: %s' % str(e))
@@ -2453,7 +2456,7 @@ class Tribe(object):
             family.detections = family._uniq().detections
             family.catalog = get_catalog(family.detections)
         if return_stream:
-            return party, st
+            return party, stream
         else:
             return party
 


### PR DESCRIPTION
This PR changes `eqcorrscan.core.match_filter.Tribe.client_detect` to return the whole stream used for the detection run if `return_stream` is set to True.  I think this is the expected behaviour, but it will lead to large amounts of memory being taken up if the users is not careful.