### PR TITLE
Change trim to slice to preserve trace

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-## Develop
+## Current
+* Fix bug with \_group_process
+* Force NumPy version
+
+## 0.2.4
 * Increase test coverage (edge-cases) in template_gen;
 * Fix bug in template_gen.extract_from_stack for duplicate channels in
 template;

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -3113,8 +3113,8 @@ def _group_process(template_group, parallel, debug, cores, stream, daylong,
         if not daylong:
             kwargs.update(
                 {'endtime': kwargs['starttime'] + master.process_length})
-            chunk_stream = stream.trim(starttime=kwargs['starttime'],
-                                       endtime=kwargs['endtime']).copy()
+            chunk_stream = stream.slice(starttime=kwargs['starttime'],
+                                        endtime=kwargs['endtime']).copy()
         else:
             chunk_stream = stream.copy()
         processed_streams.append(func(st=chunk_stream, **kwargs))


### PR DESCRIPTION
Using trim method in _group_process destroys the stream for n_chunks > 1.