### PR TITLE
Don't make pep8 tests run during pytest.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=eqcorrscan/doc .* eqcorrscan/scripts build pyasdf eqcorrscan/lib eqcorrscan/utils/src
-addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules --pep8 -n 2
+addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules -n 2


### PR DESCRIPTION
This **PR** is to test the enabling of [Stickler.ci](https://stickler-ci.com/), and remove pep8 tests from travis and appveyor (because these should be taken care of by Stickler).

This closes #124 