### PR TITLE
Lag-calc method for multiple templates sometimes gives the wrong answer

### DIFF
--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -22,7 +22,6 @@ from eqcorrscan.core.match_filter import read_detections, get_catalog
 from eqcorrscan.core.match_filter import write_catalog, extract_from_stream
 from eqcorrscan.core.match_filter import Tribe, Template, Party, Family
 from eqcorrscan.core.match_filter import read_party, read_tribe, _spike_test
-from eqcorrscan.tutorials.get_geonet_events import get_geonet_events
 from eqcorrscan.utils import pre_processing, catalog_utils
 from eqcorrscan.utils.correlate import fftw_normxcorr, numpy_normxcorr
 
@@ -140,12 +139,13 @@ class TestSynthData(unittest.TestCase):
 class TestGeoNetCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        client = Client('GEONET')
+        client = Client('http://beta-service.geonet.org.nz')
         cls.t1 = UTCDateTime(2016, 9, 4)
         cls.t2 = cls.t1 + 86400
-        catalog = get_geonet_events(
-            startdate=cls.t1, enddate=cls.t2, minmag=4, minlat=-49, maxlat=-35,
-            minlon=175.0, maxlon=185.0)
+        # catalog = get_geonet_events(
+        catalog = client.get_events(
+            starttime=cls.t1, endtime=cls.t2, minmagnitude=4, minlatitude=-49,
+            maxlatitude=-35, minlongitude=175.0, maxlongitude=185.0)
         catalog = catalog_utils.filter_picks(
             catalog, channels=['EHZ'], top_n_picks=5)
         for event in catalog:
@@ -156,7 +156,8 @@ class TestGeoNetCase(unittest.TestCase):
             event.picks.append(extra_pick)
         cls.tribe = Tribe()
         cls.tribe.construct(
-            method='from_client', catalog=catalog, client_id='GEONET',
+            method='from_client', catalog=catalog,
+            client_id='http://beta-service.geonet.org.nz',
             lowcut=2.0, highcut=9.0, samp_rate=50.0, filt_order=4,
             length=3.0, prepick=0.15, swin='all', process_len=3600)
         cls.templates = [t.st for t in cls.tribe.templates]
@@ -232,7 +233,7 @@ class TestGeoNetCase(unittest.TestCase):
                 plotdir='.', cores=1)
 
     def test_geonet_tribe_detect(self):
-        client = Client('GEONET')
+        client = Client('http://beta-service.geonet.org.nz')
         # Try to force issues with starting samples on wrong day for geonet
         # data
         tribe = self.tribe.copy()

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -145,7 +145,7 @@ class TestGeoNetCase(unittest.TestCase):
         # catalog = get_geonet_events(
         catalog = client.get_events(
             starttime=cls.t1, endtime=cls.t2, minmagnitude=4, minlatitude=-49,
-            maxlatitude=-35, minlongitude=175.0, maxlongitude=185.0)
+            maxlatitude=-35, minlongitude=175.0, maxlongitude=180.0)
         catalog = catalog_utils.filter_picks(
             catalog, channels=['EHZ'], top_n_picks=5)
         for event in catalog:

--- a/eqcorrscan/tests/sfile_util_test.py
+++ b/eqcorrscan/tests/sfile_util_test.py
@@ -33,13 +33,13 @@ class TestSfileMethods(unittest.TestCase):
             from obspy.fdsn.header import FDSNException
         import warnings
 
-        event_list = [('GEONET', '2016p008122'),
+        event_list = [('http://beta-service.geonet.org.nz', '2016p008122'),
                       ('NCEDC', '72572665'),
                       ('https://earthquake.usgs.gov', 'nc72597260')]
         for event_info in event_list:
             try:
                 client = Client(event_info[0])
-                if event_info[0] == 'GEONET':
+                if event_info[0] == 'http://beta-service.geonet.org.nz':
                     data_stream = client.\
                         _download('http://quakeml.geonet.org.nz/' +
                                   'quakeml/1.2/' + event_info[1])

--- a/eqcorrscan/tests/subspace_test.py
+++ b/eqcorrscan/tests/subspace_test.py
@@ -379,22 +379,26 @@ def get_test_data():
     :return: List of cut templates with no filters applied
     :rtype: list
     """
-    from eqcorrscan.tutorials.get_geonet_events import get_geonet_events
     from obspy import UTCDateTime
     from eqcorrscan.utils.catalog_utils import filter_picks
     from eqcorrscan.utils.clustering import space_cluster
     from obspy.clients.fdsn import Client
 
-    cat = get_geonet_events(minlat=-40.98, maxlat=-40.85, minlon=175.4,
-                            maxlon=175.5, startdate=UTCDateTime(2016, 5, 11),
-                            enddate=UTCDateTime(2016, 5, 13))
+    client = Client('http://beta-service.geonet.org.nz')
+    cat = client.get_events(minlatitude=-40.98, maxlatitude=-40.85,
+                            minlongitude=175.4, maxlongitude=175.5,
+                            starttime=UTCDateTime(2016, 5, 11),
+                            endtime=UTCDateTime(2016, 5, 13))
+    # cat = get_geonet_events(minlat=-40.98, maxlat=-40.85, minlon=175.4,
+    #                         maxlon=175.5, startdate=UTCDateTime(2016, 5, 11),
+    #                         enddate=UTCDateTime(2016, 5, 13))
     cat = filter_picks(catalog=cat, top_n_picks=5)
     stachans = list(set([(pick.waveform_id.station_code,
                           pick.waveform_id.channel_code) for event in cat
                          for pick in event.picks]))
     clusters = space_cluster(catalog=cat, d_thresh=2, show=False)
     cluster = sorted(clusters, key=lambda c: len(c))[-1]
-    client = Client('GEONET')
+    client = Client('http://beta-service.geonet.org.nz')
     design_set = []
     bulk_info = []
     for event in cluster:

--- a/eqcorrscan/tests/template_gen_test.py
+++ b/eqcorrscan/tests/template_gen_test.py
@@ -26,7 +26,6 @@ from eqcorrscan.core.template_gen import multi_template_gen, from_contbase
 from eqcorrscan.core.template_gen import template_gen, extract_from_stack
 from eqcorrscan.core.template_gen import from_sfile, TemplateGenError
 from eqcorrscan.tutorials.template_creation import mktemplates
-from eqcorrscan.tutorials.get_geonet_events import get_geonet_events
 from eqcorrscan.utils.catalog_utils import filter_picks
 from eqcorrscan.utils.sfile_util import eventtosfile, read_event
 
@@ -81,12 +80,18 @@ class TestTemplateGeneration(unittest.TestCase):
     def test_not_delayed(self):
         """Test the method of template_gen without applying delays to
         channels."""
-        cat = get_geonet_events(minlat=-40.98, maxlat=-40.85, minlon=175.4,
-                                maxlon=175.5,
-                                startdate=UTCDateTime(2016, 5, 1),
-                                enddate=UTCDateTime(2016, 5, 2))
+        client = Client('http://beta-service.geonet.org.nz')
+        cat = client.get_events(
+            minlatitude=-40.98, maxlatitude=-40.85, minlongitude=175.4,
+            maxlongitude=175.5, starttime=UTCDateTime(2016, 5, 1),
+            endtime=UTCDateTime(2016, 5, 2))
+        # cat = get_geonet_events(minlat=-40.98, maxlat=-40.85, minlon=175.4,
+        #                         maxlon=175.5,
+        #                         startdate=UTCDateTime(2016, 5, 1),
+        #                         enddate=UTCDateTime(2016, 5, 2))
         cat = filter_picks(catalog=cat, top_n_picks=5)
-        template = from_client(catalog=cat, client_id='GEONET',
+        template = from_client(catalog=cat,
+                               client_id='http://beta-service.geonet.org.nz',
                                lowcut=None, highcut=None, samp_rate=100.0,
                                filt_order=4, length=10.0, prepick=0.5,
                                swin='all', process_len=3600,
@@ -106,7 +111,7 @@ class TestTemplateGeneration(unittest.TestCase):
         Will download data from server and store in various databases,
         then create templates using the various methods.
         """
-        client = Client('GEONET')
+        client = Client('http://beta-service.geonet.org.nz')
         # get the events
         catalog = Catalog()
         data_stream = client._download('http://quakeml.geonet.org.nz/' +


### PR DESCRIPTION
This issue relates to `eqcorrscan.core.lag_calc.lag_calc`. When using multiple templates, LagCalcErrors are raised, when for the same templates and stream, running templates individually does not raise such an error.  The following (large - need to generate a smaller tests-case) results in the error:
```python
from eqcorrscan.core.match_filter import Tribe
from eqcorrscan.utils.catalog_utils import filter_picks
from eqcorrscan.utils.plotting import (pretty_template_plot,
                                       detection_multiplot)
from obspy.clients.fdsn import Client
from obspy import UTCDateTime

client = Client('NCEDC')
t1 = UTCDateTime(2004, 9, 28)
t2 = t1 + 86400
catalog = client.get_events(
    starttime=t1, endtime=t2, minmagnitude=2.5, minlatitude=35.7,
    maxlatitude=36.1, minlongitude=-120.6, maxlongitude=-120.2,
    includearrivals=True)
catalog = filter_picks(catalog, top_n_picks=5)
tribe = Tribe().construct(
     method='from_client', catalog=catalog, client_id='NCEDC', lowcut=4.0,
     highcut=15.0,  samp_rate=40.0, filt_order=4, length=6.0, prepick=0.1,
     swin='all', process_len=21600)
repicked_catalog = party.lag_calc(
     stream, pre_processed=False, shift_len=0.2, min_cc=0.4)
```
However, running the following loop raise no error:
```python
from obspy.core.event import Catalog
repicked_catalog = Catalog()
for family in party:              
    print(family)
    repicked_catalog += family.lag_calc(stream, pre_processed=False, shift_len=0.2, min_cc=0.4)
```

This issue possibly relates to `eqcorrscan.core.lag_calc._prepare_data`.

To do:
 - [ ] Prepare a smaller broken example
 - [ ] Debug!

Note that merging this should trigger a patch release (0.2.5).