### PR TITLE
Lag-calc method for multiple templates sometimes gives the wrong answer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,8 @@
 * Change internals of *eqcorrscan.core.lag_calc._prepare_data* to use a
   dictionary for delays, and to work correctly! Issues arose from not checking
   for masked data properly and not checking length properly.
+* Fix bug in match_filter.match_filter when checking for equal length traces,
+  length count was one sample too short.
 
 ## 0.2.4
 * Increase test coverage (edge-cases) in template_gen;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 ## Current
 * Fix bug with \_group_process
 * Force NumPy version
+* Add tests for lag-calc issue with preparing data
+* Change internals of *eqcorrscan.core.lag_calc._prepare_data* to use a
+  dictionary for delays, and to work correctly! Issues arose from not checking
+  for masked data properly and not checking length properly.
 
 ## 0.2.4
 * Increase test coverage (edge-cases) in template_gen;

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -414,7 +414,7 @@ def _prepare_data(detect_data, detections, template, delays,
             background = detect_data.slice(
                 starttime=detection.detect_time - (shift_len + 5),
                 endtime=detection.detect_time +
-                        shift_len + max_delay + 7).copy()
+                shift_len + max_delay + 7).copy()
             for tr in background:
                 if len(tr.data) == 0:
                     background.remove(tr)

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -325,14 +325,13 @@ def _day_loop(detection_streams, template, min_cc, detections,
                 pre_lag_ccsum=detections[i].detect_val,
                 detect_chans=detections[i].no_chans,
                 horizontal_chans=horizontal_chans,
-                vertical_chans=vertical_chans,
-                debug=debug))
+                vertical_chans=vertical_chans, debug=debug))
     temp_catalog = Catalog()
     temp_catalog.events = [event_tup[1] for event_tup in events_list]
     return temp_catalog
 
 
-def _prepare_data(detect_data, detections, zipped_templates, delays,
+def _prepare_data(detect_data, detections, template, delays,
                   shift_len, plot):
     """
     Prepare data for lag_calc - reduce memory here.
@@ -343,12 +342,11 @@ def _prepare_data(detect_data, detections, zipped_templates, delays,
     :param detections:
         List of :class:`eqcorrscan.core.match_filter.Detection` to get
         data for.
-    :type zipped_templates: zip
-    :param zipped_templates: Zipped list of (template_name, template)
+    :type template: tuple
+    :param template: tuple of (template_name, template)
     :type delays: list
     :param delays:
-        List of lists of the delays for each template in the form:
-        [(template_name, [(station, channel, delay)])]
+        Dictionary of delay times in seconds keyed by sta.channel.
     :type shift_len: float
     :param shift_len: Shift length in seconds allowed for picking.
     :type plot: bool
@@ -360,49 +358,31 @@ def _prepare_data(detect_data, detections, zipped_templates, delays,
     """
     detect_streams = []
     for detection in detections:
+        if detection.template_name != template[0]:
+            continue
         # Stream to be saved for new detection
         detect_stream = []
         max_delay = 0
-        template_st = [t for t in zipped_templates
-                       if str(t[0]) == str(detection.template_name)]
-        if len(template_st) > 0:
-            template_st = template_st[0]
-        else:
-            warnings.warn('No template with name: %s' %
-                          detection.template_name)
-            for t in zipped_templates:
-                print(t)
-            continue
         for tr in detect_data:
-            tr_copy = tr.copy()
-            # Right now, copying each trace hundreds of times...
-            template = template_st[1].select(station=tr.stats.station,
-                                             channel=tr.stats.channel)
-            if template:
+            template_tr = template[1].select(
+                station=tr.stats.station, channel=tr.stats.channel)
+            if len(template_tr) >= 1:
                 # Save template trace length in seconds
-                template_len = len(template[0]) / \
-                    template[0].stats.sampling_rate
+                template_len = (
+                    len(template_tr[0]) / template_tr[0].stats.sampling_rate)
             else:
                 continue
                 # If there is no template-data match then skip the rest
                 # of the trace loop.
             # Grab the delays for the desired template: [(sta, chan, delay)]
-            delay = []
-            for d in delays:
-                if d[0] == detection.template_name:
-                    delay.append(d)
-            delay = delay[0][1]
             # Now grab the delay for the desired trace for this template
-            delay = [d for d in delay if d[0] == tr.stats.station and
-                     d[1] == tr.stats.channel][0][2]
+            delay = delays[tr.stats.station + '.' + tr.stats.channel]
             if delay > max_delay:
                 max_delay = delay
-            detect_stream.append(tr_copy.trim(starttime=detection.detect_time -
-                                              shift_len + delay,
-                                              endtime=detection.detect_time +
-                                              delay + shift_len +
-                                              template_len))
-            del tr_copy
+            detect_stream.append(tr.slice(
+                starttime=detection.detect_time - shift_len + delay,
+                endtime=detection.detect_time + delay + shift_len +
+                template_len).copy())
         for tr in detect_stream:
             if len(tr.data) == 0:
                 msg = ('No data in %s.%s for detection at time %s' %
@@ -410,17 +390,17 @@ def _prepare_data(detect_data, detections, zipped_templates, delays,
                         detection.detect_time))
                 warnings.warn(msg)
                 detect_stream.remove(tr)
-            elif tr.stats.endtime - tr.stats.starttime < template_len:
+            elif tr.stats.endtime - tr.stats.starttime < (
+                        2 * shift_len) + template_len:
                 msg = ("Insufficient data for %s.%s will not use."
                        % (tr.stats.station, tr.stats.channel))
                 warnings.warn(msg)
                 detect_stream.remove(tr)
-            elif len(tr.split()) > 1:
+            elif np.ma.is_masked(tr.data):
                 msg = ("Masked data found for %s.%s, will not use."
                        % (tr.stats.station, tr.stats.channel))
                 warnings.warn(msg)
                 detect_stream.remove(tr)
-
         # Check for duplicate traces
         stachans = [(tr.stats.station, tr.stats.channel)
                     for tr in detect_stream]
@@ -431,9 +411,10 @@ def _prepare_data(detect_data, detections, zipped_templates, delays,
                        % (key[0], key[1]))
                 raise LagCalcError(msg)
         if plot:
-            background = detect_data.copy().trim(
+            background = detect_data.slice(
                 starttime=detection.detect_time - (shift_len + 5),
-                endtime=detection.detect_time + shift_len + max_delay + 7)
+                endtime=detection.detect_time +
+                        shift_len + max_delay + 7).copy()
             for tr in background:
                 if len(tr.data) == 0:
                     background.remove(tr)
@@ -576,16 +557,17 @@ def lag_calc(detections, detect_data, template_names, templates,
     detect_stachans = [(tr.stats.station, tr.stats.channel)
                        for tr in detect_data]
     for template in zipped_templates:
-        temp_delays = []
+        temp_delays = {}
         # Remove channels not present in continuous data
         _template = template[1].copy()
         for tr in _template:
             if (tr.stats.station, tr.stats.channel) not in detect_stachans:
                 _template.remove(tr)
         for tr in _template:
-            temp_delays.append((tr.stats.station, tr.stats.channel,
-                                tr.stats.starttime - _template.
-                                sort(['starttime'])[0].stats.starttime))
+            temp_delays.update(
+                {tr.stats.station + '.' + tr.stats.channel:
+                 tr.stats.starttime -
+                 _template.sort(['starttime'])[0].stats.starttime})
         delays.append((template[0], temp_delays))
         del _template
     # Segregate detections by template, then feed to day_loop
@@ -594,12 +576,13 @@ def lag_calc(detections, detect_data, template_names, templates,
         print('Running lag-calc for template %s' % template[0])
         template_detections = [detection for detection in detections
                                if detection.template_name == template[0]]
+        t_delays = [d for d in delays if d[0] == template[0]][0][1]
         if debug > 2:
             print('There are %i detections' % len(template_detections))
         detect_streams = _prepare_data(
             detect_data=detect_data, detections=template_detections,
-            zipped_templates=zipped_templates, delays=delays,
-            shift_len=shift_len, plot=prep_plot)
+            template=template, delays=t_delays, shift_len=shift_len,
+            plot=prep_plot)
         detect_streams = [detect_stream[1] for detect_stream in detect_streams]
         if len(template_detections) > 0:
             template_cat = _day_loop(

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2525,7 +2525,10 @@ class Tribe(object):
             except Exception as e:
                 print('Error, routine incomplete, returning incomplete Party')
                 print('Error: %s' % str(e))
-                return party
+                if return_stream:
+                    return party, stream
+                else:
+                    return party
         for family in party:
             if family is not None:
                 family.detections = family._uniq().detections
@@ -3708,6 +3711,7 @@ def match_filter(template_names, template_list, st, threshold,
     max_end_time = max([tr.stats.endtime for tr in stream])
     longest_trace_length = stream[0].stats.sampling_rate * (max_end_time -
                                                             min_start_time)
+    longest_trace_length += 1
     for tr in stream:
         if not tr.stats.npts == longest_trace_length:
             msg = 'Data are not equal length, padding short traces'
@@ -3819,7 +3823,7 @@ def match_filter(template_names, template_list, st, threshold,
     templates = _templates
     _template_names = used_template_names
     if debug >= 2:
-        print('Starting the correlation run for this day')
+        print('Starting the correlation run for these data')
     if debug >= 3:
         for template in templates:
             print(template)

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -647,7 +647,7 @@ class Party(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, parallel=True,
-                 debug=0):
+                 overlap='calculate', debug=0):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -686,6 +686,13 @@ class Party(object):
             To generate a plot for every detection or not, defaults to False
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
+        :type overlap: float
+        :param overlap:
+            Either None, "calculate" or a float of number of seconds to
+            overlap detection streams by.  This is to counter the effects of
+            the delay-and-stack in calcualting cross-correlation sums. Setting
+            overlap = "calculate" will work out the appropriate overlap based
+            on the maximum lags within templates.
         :type debug: int
         :param debug: Debug output level, 0-5 with 5 being the most output.
 
@@ -751,18 +758,28 @@ class Party(object):
                 detection_groups.remove(det_group)
         # Process the data for each group and time-chunk
         for group, det_group in zip(template_groups, detection_groups):
+            lap = 0.0
+            for template in group:
+                starts = [t.stats.starttime for t in
+                          template.st.sort(['starttime'])]
+                if starts[-1] - starts[0] > lap:
+                    lap = starts[-1] - starts[0]
+            if overlap is None:
+                lap = 0.0
+            elif isinstance(overlap, float):
+                lap = overlap
             if not pre_processed:
                 processed_streams = _group_process(
                     template_group=group, cores=cores, parallel=parallel,
                     stream=stream.copy(), debug=debug, daylong=False,
-                    ignore_length=False, overlap=0.0)
+                    ignore_length=False, overlap=lap)
                 processed_stream = Stream()
                 for p in processed_streams:
                     processed_stream += p
                 processed_stream.merge()
             else:
                 processed_stream = stream
-            print(stream)
+            print(processed_stream)
             temp_cat = lag_calc(
                 detections=det_group, detect_data=processed_stream,
                 template_names=[t.name for t in group],
@@ -3105,8 +3122,7 @@ def _group_process(template_group, parallel, debug, cores, stream, daylong,
     n_chunks = int((endtime - starttime + 1) / (master.process_length -
                                                 overlap))
     if n_chunks == 0:
-        print(
-            'Data must be process_length or longer, not computing detections')
+        print('Data must be process_length or longer, not computing')
     for i in range(n_chunks):
         kwargs.update(
             {'starttime': starttime + (i * (master.process_length - overlap))})

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -776,10 +776,10 @@ class Party(object):
                 processed_stream = Stream()
                 for p in processed_streams:
                     processed_stream += p
-                processed_stream.merge()
+                processed_stream.merge(method=1)
+                print(processed_stream)
             else:
                 processed_stream = stream
-            print(processed_stream)
             temp_cat = lag_calc(
                 detections=det_group, detect_data=processed_stream,
                 template_names=[t.name for t in group],

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -11,7 +11,7 @@ import os
 import unittest
 
 import numpy as np
-from obspy import read, UTCDateTime, read_events, Catalog, Stream
+from obspy import read, UTCDateTime, read_events, Catalog, Stream, Trace
 from obspy.clients.fdsn import Client
 from obspy.core.event import Pick, Event
 from obspy.core.util.base import NamedTemporaryFile
@@ -135,6 +135,25 @@ class TestSynthData(unittest.TestCase):
     def test_extra_templates(self):
         # Test case where there are non-matching streams in the data
         test_match_filter(template_excess=True)
+
+    def test_onesamp_diff(self):
+        """Tests to check that traces in stream are set to same length."""
+        stream = Stream(traces=[
+            Trace(data=np.random.randn(100)),
+            Trace(data=np.random.randn(101))])
+        stream[0].stats.sampling_rate = 40
+        stream[0].stats.station = 'A'
+        stream[1].stats.sampling_rate = 40
+        stream[1].stats.station = 'B'
+        templates = [Stream(traces=[Trace(data=np.random.randn(20)),
+                                    Trace(data=np.random.randn(20))])]
+        templates[0][0].stats.sampling_rate = 40
+        templates[0][0].stats.station = 'A'
+        templates[0][1].stats.sampling_rate = 40
+        templates[0][1].stats.station = 'B'
+        match_filter(template_names=['1'], template_list=templates, st=stream,
+                     threshold=8, threshold_type='MAD', trig_int=1,
+                     plotvar=False)
 
 
 class TestGeoNetCase(unittest.TestCase):


### PR DESCRIPTION
This PR relates to issue #126 regarding `eqcorrscan.core.lag_calc.lag_calc`. When using multiple templates, LagCalcErrors are raised, when for the same templates and stream, running templates individually does not raise such an error.  The following (large - need to generate a smaller tests-case) results in the error:
```python
from eqcorrscan.core.match_filter import Tribe
from eqcorrscan.utils.catalog_utils import filter_picks
from eqcorrscan.utils.plotting import (pretty_template_plot,
                                       detection_multiplot)
from obspy.clients.fdsn import Client
from obspy import UTCDateTime

client = Client('NCEDC')
t1 = UTCDateTime(2004, 9, 28)
t2 = t1 + 86400
catalog = client.get_events(
    starttime=t1, endtime=t2, minmagnitude=2.5, minlatitude=35.7,
    maxlatitude=36.1, minlongitude=-120.6, maxlongitude=-120.2,
    includearrivals=True)
catalog = filter_picks(catalog, top_n_picks=5)
tribe = Tribe().construct(
     method='from_client', catalog=catalog, client_id='NCEDC', lowcut=4.0,
     highcut=15.0,  samp_rate=40.0, filt_order=4, length=6.0, prepick=0.1,
     swin='all', process_len=21600)
repicked_catalog = party.lag_calc(
     stream, pre_processed=False, shift_len=0.2, min_cc=0.4)
```
However, running the following loop raise no error:
```python
from obspy.core.event import Catalog
repicked_catalog = Catalog()
for family in party:              
    print(family)
    repicked_catalog += family.lag_calc(stream, pre_processed=False, shift_len=0.2, min_cc=0.4)
```

This issue possibly relates to `eqcorrscan.core.lag_calc._prepare_data`.

To do:
 - [x] Prepare a smaller broken example
 - [x] Debug!

When merged this should prompt a new patch release.