### PR TITLE
Time-domain cross-correlation not correctly normalised

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -37,3 +37,5 @@ parsers:
       method: false
   javascript:
     enable_partials: false
+ignore:
+  eqcorrscan-jsyvc


### PR DESCRIPTION
Time-domain cross-correlation in EQcorrscan was not originally designed to be used for long time-series with variable means, and as such does not implement normalisation correctly.  If we are to expose time-domain methods more readily (as we would in #119), then this function needs to be adjusted.

In general I think this should be corrected anyway so that users do not get unexpected results.