### PR TITLE
Add support for indexing by template-name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Current
 * Fix bug with \_group_process
 * Force NumPy version
+* Support indexing of Tribe and Party objects by template-name.
 
 ## 0.2.4
 * Increase test coverage (edge-cases) in template_gen;

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,3 +37,5 @@ parsers:
       method: false
   javascript:
     enable_partials: false
+ignore:
+  eqcorrscan-jsyvc

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -318,7 +318,9 @@ class Party(object):
             return None
         if isinstance(index, slice):
             return self.__class__(families=self.families.__getitem__(index))
-        elif isinstance(index, str):
+        elif isinstance(index, int):
+            return self.families.__getitem__(index)
+        else:
             _index = [i for i, family in enumerate(self.families)
                       if family.template.name == index]
             try:
@@ -326,8 +328,6 @@ class Party(object):
             except IndexError:
                 warnings.warn('Family: %s not in party' % index)
                 return []
-        else:
-            return self.families.__getitem__(index)
 
     def __len__(self):
         """
@@ -2006,7 +2006,9 @@ class Tribe(object):
         """
         if isinstance(index, slice):
             return self.__class__(templates=self.templates.__getitem__(index))
-        elif isinstance(index, str):
+        elif isinstance(index, int):
+            return self.templates.__getitem__(index)
+        else:
             _index = [i for i, t in enumerate(self.templates)
                       if t.name == index]
             try:
@@ -2014,8 +2016,6 @@ class Tribe(object):
             except IndexError:
                 warnings.warn('Template: %s not in tribe' % index)
                 return []
-        else:
-            return self.templates.__getitem__(index)
 
     def sort(self):
         """

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -284,7 +284,7 @@ class Party(object):
         """
         Get families from the Party. Can accept either an index or slice.
 
-        :param index: Family number or slice.
+        :param index: Family number or name, or slice.
         :return: Party (if a slice is given) or a single Family
 
         .. rubric:: Example
@@ -305,11 +305,27 @@ class Party(object):
         ...                         Family(template=Template(name='c'))])
         >>> party[1:]
         Party of 2 Families.
+
+        Extract a single family by template name:
+
+        >>> party = Party(families=[Family(template=Template(name='a')),
+        ...                         Family(template=Template(name='b')),
+        ...                         Family(template=Template(name='c'))])
+        >>> party['b']
+        Family of 0 detections from template b
         """
         if len(self.families) == 0:
             return None
         if isinstance(index, slice):
             return self.__class__(families=self.families.__getitem__(index))
+        elif isinstance(index, str):
+            _index = [i for i, family in enumerate(self.families)
+                      if family.template.name == index]
+            try:
+                return self.families.__getitem__(_index[0])
+            except IndexError:
+                warnings.warn('Family: %s not in party' % index)
+                return []
         else:
             return self.families.__getitem__(index)
 
@@ -1990,6 +2006,14 @@ class Tribe(object):
         """
         if isinstance(index, slice):
             return self.__class__(templates=self.templates.__getitem__(index))
+        elif isinstance(index, str):
+            _index = [i for i, t in enumerate(self.templates)
+                      if t.name == index]
+            try:
+                return self.templates.__getitem__(_index[0])
+            except IndexError:
+                warnings.warn('Template: %s not in tribe' % index)
+                return []
         else:
             return self.templates.__getitem__(index)
 

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -891,6 +891,12 @@ class TestMatchObjects(unittest.TestCase):
                 lowcut=2.0, highcut=9.0, samp_rate=50.0, filt_order=4,
                 length=3.0, prepick=0.15, swin='all', process_len=6)
 
+    def test_slicing_by_name(self):
+        """Check that slicing by template name works as expected"""
+        t_name = self.tribe[2].name
+        self.assertTrue(self.tribe[2] == self.tribe[t_name])
+        self.assertTrue(self.party[2] == self.party[t_name])
+
 
 def test_match_filter(
         debug=0, plotvar=False, extract_detections=False, threshold_type='MAD',


### PR DESCRIPTION
This PR adds support for extracting a Template from a Tribe by the name of the template, and similarly, extracting a Family from a Party by the name of the template.

Closes #122 