### PR TITLE
Prep for patch 0.2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,7 @@ matrix:
 
     - os: osx
       env:
-        - PYTHON_VERSION=2.7
-    - os: osx
-      env:
         - PYTHON_VERSION=3.5
-    - os: osx
-      env:
-        - PYTHON_VERSION=3.6
 
 sudo: false
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Current
+## 0.2.5
 * Fix bug with \_group_process that resulted in stalled processes.
 * Force NumPy version
 * Support indexing of Tribe and Party objects by template-name.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 ## Current
-* Fix bug with \_group_process
+* Fix bug with \_group_process that resulted in stalled processes.
 * Force NumPy version
+* Add tests for lag-calc issue with preparing data
+* Change internals of *eqcorrscan.core.lag_calc._prepare_data* to use a
+  dictionary for delays, and to work correctly! Issues arose from not checking
+  for masked data properly and not checking length properly.
+* Fix bug in match_filter.match_filter when checking for equal length traces,
+  length count was one sample too short.
 
 ## 0.2.4
 * Increase test coverage (edge-cases) in template_gen;

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Current
 * Fix bug with \_group_process that resulted in stalled processes.
 * Force NumPy version
+* Support indexing of Tribe and Party objects by template-name.
 * Add tests for lag-calc issue with preparing data
 * Change internals of *eqcorrscan.core.lag_calc._prepare_data* to use a
   dictionary for delays, and to work correctly! Issues arose from not checking

--- a/codecov.yml
+++ b/codecov.yml
@@ -37,3 +37,5 @@ parsers:
       method: false
   javascript:
     enable_partials: false
+ignore:
+  eqcorrscan-jsyvc

--- a/eqcorrscan/__init__.py
+++ b/eqcorrscan/__init__.py
@@ -14,7 +14,7 @@ import warnings
 __all__ = ['core', 'utils', 'tutorials']
 
 
-__version__ = '0.2.4'
+__version__ = '0.2.5'
 
 
 # Cope with changes to name-space to remove most of the camel-case

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -284,7 +284,7 @@ class Party(object):
         """
         Get families from the Party. Can accept either an index or slice.
 
-        :param index: Family number or slice.
+        :param index: Family number or name, or slice.
         :return: Party (if a slice is given) or a single Family
 
         .. rubric:: Example
@@ -305,13 +305,29 @@ class Party(object):
         ...                         Family(template=Template(name='c'))])
         >>> party[1:]
         Party of 2 Families.
+
+        Extract a single family by template name:
+
+        >>> party = Party(families=[Family(template=Template(name='a')),
+        ...                         Family(template=Template(name='b')),
+        ...                         Family(template=Template(name='c'))])
+        >>> party['b']
+        Family of 0 detections from template b
         """
         if len(self.families) == 0:
             return None
         if isinstance(index, slice):
             return self.__class__(families=self.families.__getitem__(index))
-        else:
+        elif isinstance(index, int):
             return self.families.__getitem__(index)
+        else:
+            _index = [i for i, family in enumerate(self.families)
+                      if family.template.name == index]
+            try:
+                return self.families.__getitem__(_index[0])
+            except IndexError:
+                warnings.warn('Family: %s not in party' % index)
+                return []
 
     def __len__(self):
         """
@@ -2007,8 +2023,16 @@ class Tribe(object):
         """
         if isinstance(index, slice):
             return self.__class__(templates=self.templates.__getitem__(index))
-        else:
+        elif isinstance(index, int):
             return self.templates.__getitem__(index)
+        else:
+            _index = [i for i, t in enumerate(self.templates)
+                      if t.name == index]
+            try:
+                return self.templates.__getitem__(_index[0])
+            except IndexError:
+                warnings.warn('Template: %s not in tribe' % index)
+                return []
 
     def sort(self):
         """

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -647,7 +647,7 @@ class Party(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, parallel=True,
-                 debug=0):
+                 overlap='calculate', debug=0):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -686,6 +686,13 @@ class Party(object):
             To generate a plot for every detection or not, defaults to False
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
+        :type overlap: float
+        :param overlap:
+            Either None, "calculate" or a float of number of seconds to
+            overlap detection streams by.  This is to counter the effects of
+            the delay-and-stack in calcualting cross-correlation sums. Setting
+            overlap = "calculate" will work out the appropriate overlap based
+            on the maximum lags within templates.
         :type debug: int
         :param debug: Debug output level, 0-5 with 5 being the most output.
 
@@ -751,18 +758,28 @@ class Party(object):
                 detection_groups.remove(det_group)
         # Process the data for each group and time-chunk
         for group, det_group in zip(template_groups, detection_groups):
+            lap = 0.0
+            for template in group:
+                starts = [t.stats.starttime for t in
+                          template.st.sort(['starttime'])]
+                if starts[-1] - starts[0] > lap:
+                    lap = starts[-1] - starts[0]
+            if overlap is None:
+                lap = 0.0
+            elif isinstance(overlap, float):
+                lap = overlap
             if not pre_processed:
                 processed_streams = _group_process(
                     template_group=group, cores=cores, parallel=parallel,
                     stream=stream.copy(), debug=debug, daylong=False,
-                    ignore_length=False, overlap=0.0)
+                    ignore_length=False, overlap=lap)
                 processed_stream = Stream()
                 for p in processed_streams:
                     processed_stream += p
-                processed_stream.merge()
+                processed_stream.merge(method=1)
+                print(processed_stream)
             else:
                 processed_stream = stream
-            print(stream)
             temp_cat = lag_calc(
                 detections=det_group, detect_data=processed_stream,
                 template_names=[t.name for t in group],
@@ -2508,7 +2525,10 @@ class Tribe(object):
             except Exception as e:
                 print('Error, routine incomplete, returning incomplete Party')
                 print('Error: %s' % str(e))
-                return party
+                if return_stream:
+                    return party, stream
+                else:
+                    return party
         for family in party:
             if family is not None:
                 family.detections = family._uniq().detections
@@ -3105,8 +3125,7 @@ def _group_process(template_group, parallel, debug, cores, stream, daylong,
     n_chunks = int((endtime - starttime + 1) / (master.process_length -
                                                 overlap))
     if n_chunks == 0:
-        print(
-            'Data must be process_length or longer, not computing detections')
+        print('Data must be process_length or longer, not computing')
     for i in range(n_chunks):
         kwargs.update(
             {'starttime': starttime + (i * (master.process_length - overlap))})
@@ -3692,6 +3711,7 @@ def match_filter(template_names, template_list, st, threshold,
     max_end_time = max([tr.stats.endtime for tr in stream])
     longest_trace_length = stream[0].stats.sampling_rate * (max_end_time -
                                                             min_start_time)
+    longest_trace_length += 1
     for tr in stream:
         if not tr.stats.npts == longest_trace_length:
             msg = 'Data are not equal length, padding short traces'
@@ -3803,7 +3823,7 @@ def match_filter(template_names, template_list, st, threshold,
     templates = _templates
     _template_names = used_template_names
     if debug >= 2:
-        print('Starting the correlation run for this day')
+        print('Starting the correlation run for these data')
     if debug >= 3:
         for template in templates:
             print(template)

--- a/eqcorrscan/lib/multi_corr.c
+++ b/eqcorrscan/lib/multi_corr.c
@@ -293,22 +293,28 @@ int normxcorr_time(float *template, int template_len, float *image, int image_le
     // Time domain cross-correlation - requires zero-mean template and image
 	int p, k;
 	int steps = image_len - template_len + 1;
-	double numerator = 0.0, denom;
+	double numerator = 0.0, denom, mean = 0.0;
 	double auto_a = 0.0, auto_b = 0.0;
+
+    for (k=0; k < template_len; ++k){
+		mean += image[k];
+	}
+	mean = mean / template_len;
 
 	for(p = 0; p < template_len; ++p){
 		auto_a += (double) template[p] * (double) template[p];
-		numerator += (double) template[p] * (double) image[p];
-		auto_b += (double) image[p] * (double) image[p];
+		numerator += (double) template[p] * ((double) image[p] - mean);
+		auto_b += ((double) image[p] - mean) * ((double) image[p] - mean);
 	}
 	denom = sqrt(auto_a * auto_b);
 	ccc[0] = (float) (numerator / denom);
 	for(k = 1; k < steps; ++k){
+		mean = mean + (image[k + template_len - 1] - image[k - 1]) / template_len;
 	    numerator = 0.0;
 	    auto_b = 0.0;
 		for(p = 0; p < template_len; ++p){
-			numerator += (double) template[p] * (double) image[p + k];
-			auto_b += (double) image[p + k] * (double) image[p + k];
+			numerator += (double) template[p] * ((double) image[p + k] - mean);
+			auto_b += ((double) image[p + k] - mean) * ((double) image[p + k] - mean);
 		}
 		denom = sqrt(auto_a * auto_b);
 		ccc[k] = (float) (numerator / denom);

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -38,8 +38,8 @@ class CorrelateTests(unittest.TestCase):
         print('Time-domain took: %f seconds' % (toc-tic))
         self.assertTrue(np.allclose(numpy_ccc, fftw_ccc, atol=0.001))
         self.assertTrue(np.allclose(numpy_ccc, fftw_ccc_2d, atol=0.001))
-        self.assertTrue(np.allclose(numpy_ccc, time_ccc, atol=0.12))
-        self.assertTrue(np.allclose(fftw_ccc, time_ccc, atol=0.12))
+        self.assertTrue(np.allclose(numpy_ccc, time_ccc, atol=0.001))
+        self.assertTrue(np.allclose(fftw_ccc, time_ccc, atol=0.001))
 
     def test_multi_channel_xcorr(self):
         chans = ['EHZ', 'EHN', 'EHE']
@@ -97,13 +97,13 @@ class CorrelateTests(unittest.TestCase):
         # self.assertTrue(np.allclose(cccsums_t_s, cccsums_t_p, atol=0.00001))
         self.assertTrue(np.allclose(cccsums_f_s, cccsums_f_p, atol=0.00001))
         self.assertTrue(np.allclose(cccsums_f_s, cccsums_f_op, atol=0.00001))
-        if not np.allclose(cccsums_t_p, cccsums_f_s, atol=0.7):
+        if not np.allclose(cccsums_t_p, cccsums_f_s, atol=0.00001):
             import matplotlib.pyplot as plt
             plt.plot(cccsums_t_p[0], 'k', label='Time')
             plt.plot(cccsums_f_s[0], 'r', label='Frequency')
             plt.legend()
             plt.show()
-        self.assertTrue(np.allclose(cccsums_t_p, cccsums_f_s, atol=0.7))
+        self.assertTrue(np.allclose(cccsums_t_p, cccsums_f_s, atol=0.00001))
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -11,7 +11,7 @@ import os
 import unittest
 
 import numpy as np
-from obspy import read, UTCDateTime, read_events, Catalog, Stream
+from obspy import read, UTCDateTime, read_events, Catalog, Stream, Trace
 from obspy.clients.fdsn import Client
 from obspy.core.event import Pick, Event
 from obspy.core.util.base import NamedTemporaryFile
@@ -135,6 +135,25 @@ class TestSynthData(unittest.TestCase):
     def test_extra_templates(self):
         # Test case where there are non-matching streams in the data
         test_match_filter(template_excess=True)
+
+    def test_onesamp_diff(self):
+        """Tests to check that traces in stream are set to same length."""
+        stream = Stream(traces=[
+            Trace(data=np.random.randn(100)),
+            Trace(data=np.random.randn(101))])
+        stream[0].stats.sampling_rate = 40
+        stream[0].stats.station = 'A'
+        stream[1].stats.sampling_rate = 40
+        stream[1].stats.station = 'B'
+        templates = [Stream(traces=[Trace(data=np.random.randn(20)),
+                                    Trace(data=np.random.randn(20))])]
+        templates[0][0].stats.sampling_rate = 40
+        templates[0][0].stats.station = 'A'
+        templates[0][1].stats.sampling_rate = 40
+        templates[0][1].stats.station = 'B'
+        match_filter(template_names=['1'], template_list=templates, st=stream,
+                     threshold=8, threshold_type='MAD', trig_int=1,
+                     plotvar=False)
 
 
 class TestGeoNetCase(unittest.TestCase):

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -910,6 +910,12 @@ class TestMatchObjects(unittest.TestCase):
                 lowcut=2.0, highcut=9.0, samp_rate=50.0, filt_order=4,
                 length=3.0, prepick=0.15, swin='all', process_len=6)
 
+    def test_slicing_by_name(self):
+        """Check that slicing by template name works as expected"""
+        t_name = self.tribe[2].name
+        self.assertTrue(self.tribe[2] == self.tribe[t_name])
+        self.assertTrue(self.party[2] == self.party[t_name])
+
 
 def test_match_filter(
         debug=0, plotvar=False, extract_detections=False, threshold_type='MAD',

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=eqcorrscan/doc .* eqcorrscan/scripts build pyasdf eqcorrscan/lib eqcorrscan/utils/src
-addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules -n 2
+addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
 norecursedirs=eqcorrscan/doc .* eqcorrscan/scripts build pyasdf eqcorrscan/lib eqcorrscan/utils/src
-addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules
+addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules -n 2


### PR DESCRIPTION
This PR serves to update master prior to a 0.2.5 patch release.

These changes:
 - fix a couple of small bugs that affect edge-cases where data are downloaded in funky lengths
 - provide a properly normalised time-domain cross-correlation routine (which isn't fast for large cases, but is for small cases)
 - allow slicing of match-filter objects by template-name.

Once this is merged a releases need to be created:
 - [ ] on github;
 - [ ] on pypi;
 - [ ] on conda.