### PR TITLE
Try to debug missing docs

### DIFF
--- a/eqcorrscan/doc/conf.py
+++ b/eqcorrscan/doc/conf.py
@@ -17,7 +17,6 @@ import os
 import shlex
 sys.path.insert(0, os.path.abspath('../..'))
 import matplotlib
-import eqcorrscan
 
 READ_THE_DOCS = os.environ.get('READTHEDOCS', None) == 'True'
 if not READ_THE_DOCS:

--- a/eqcorrscan/doc/conf.py
+++ b/eqcorrscan/doc/conf.py
@@ -26,7 +26,7 @@ if not READ_THE_DOCS:
 # Use mock to allow for autodoc compilation without needing C based modules
 import mock
 import glob
-MOCK_MODULES = ['cv2', 'h5py', 'eqcorrscan.utils.libutils', 'utils.libutils', 'libutils']
+MOCK_MODULES = ['cv2', 'h5py', 'eqcorrscan.utils.libnames']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
 

--- a/eqcorrscan/doc/conf.py
+++ b/eqcorrscan/doc/conf.py
@@ -28,6 +28,7 @@ import glob
 MOCK_MODULES = ['cv2', 'h5py', 'eqcorrscan.utils.libutils']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
+import eqcorrscan
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.

--- a/eqcorrscan/doc/conf.py
+++ b/eqcorrscan/doc/conf.py
@@ -32,7 +32,6 @@ for mod_name in MOCK_MODULES:
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-sys.path.insert(0, os.path.abspath('../lib'))
 sys.path.insert(0, os.path.abspath('../core'))
 sys.path.insert(0, os.path.abspath('../utils'))
 

--- a/eqcorrscan/doc/conf.py
+++ b/eqcorrscan/doc/conf.py
@@ -17,6 +17,7 @@ import os
 import shlex
 sys.path.insert(0, os.path.abspath('../..'))
 import matplotlib
+import eqcorrscan
 
 READ_THE_DOCS = os.environ.get('READTHEDOCS', None) == 'True'
 if not READ_THE_DOCS:
@@ -25,10 +26,10 @@ if not READ_THE_DOCS:
 # Use mock to allow for autodoc compilation without needing C based modules
 import mock
 import glob
-MOCK_MODULES = ['cv2', 'h5py', 'eqcorrscan.utils.libutils']
+MOCK_MODULES = ['cv2', 'h5py', 'eqcorrscan.utils.libutils', 'utils.libutils', 'libutils']
 for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = mock.Mock()
-import eqcorrscan
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.


### PR DESCRIPTION
Will need to enable building this branch and check that all docs pages are present - mostly relevant (or known to be missing) are:
 - [x] [utils.clustering](http://eqcorrscan.readthedocs.io/en/docs-patch/submodules/utils.clustering.html)