### PR TITLE
Doctest examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
           command: |
             . venv/bin/activate
             py.test -m "network" -n 2
+            py.test eqcorrscan/doc/tutorials/*.rst eqcorrscan/doc/submodules/*.rst --cov-append
 
       - run:
           name: Upload to codecov

--- a/eqcorrscan/doc/submodules/utils.correlate.rst
+++ b/eqcorrscan/doc/submodules/utils.correlate.rst
@@ -89,36 +89,35 @@ for example:
 
 .. code-block:: python
 
-    import obspy
-    from eqcorrscan.utils.correlate import numpy_normxcorr, set_xcorr
-    from eqcorrscan.core.match_filter import match_filter
+    >>> import obspy
+    >>> import numpy as np
+    >>> from eqcorrscan.utils.correlate import numpy_normxcorr, set_xcorr
+    >>> from eqcorrscan.core.match_filter import match_filter
 
 
-    # generate some toy templates and stream
-    random = np.random.RandomState(42)
-    template = obspy.read()
-    stream = obspy.read()
-    for num, tr in enumerate(stream):  # iter stream and embed templates
-        data = tr.data
-        tr.data = random.randn(6000) * 5
-        tr.data[100: 100 + len(data)] = data
+    >>> # generate some toy templates and stream
+    >>> random = np.random.RandomState(42)
+    >>> template = obspy.read()
+    >>> stream = obspy.read()
+    >>> for num, tr in enumerate(stream):  # iter stream and embed templates
+    ...     data = tr.data
+    ...     tr.data = random.randn(6000) * 5
+    ...     tr.data[100: 100 + len(data)] = data
 
+    >>> # do correlation using numpy rather than fftw
+    >>> detections = match_filter(['1'], [template], stream, .5, 'absolute',
+    ...                           1, False, xcorr_func='numpy')
 
-    # do correlation using numpy rather than fftw
-    match_filter(['1'], [template], stream, .5, 'absolute', 1, False,
-                 xcorr_func='numpy')
+    >>> # do correlation using a custom function
+    >>> def custom_normxcorr(templates, stream, pads, *args, **kwargs):
+    ...     # Just to keep example short call other xcorr function
+    ...     print('calling custom xcorr function')
+    ...     return numpy_normxcorr(templates, stream, pads, *args, **kwargs)
 
-
-    # do correlation using a custom function
-    def custom_normxcorr(templates, stream, pads, *args, **kwargs):
-        # Just to keep example short call other xcorr function
-        print('calling custom xcorr function')
-        return numpy_normxcorr(templates, stream, pads, *args, **kwargs)
-
-
-    match_filter(['1'], [template], stream, .5, 'absolute', 1, False,
-                 xcorr_func=custom_normxcorr)
-    # prints "calling custom xcorr function
+    >>> detections = match_filter(
+    ...     ['1'], [template], stream, .5, 'absolute', 1, False,
+    ...     xcorr_func=custom_normxcorr) # doctest:+ELLIPSIS
+    calling custom xcorr function...
 
 
 You can also use the set_xcorr object (eqcorrscan.utils.correlate.set_xcorr)
@@ -127,13 +126,15 @@ or within the scope of a context manager:
 
 .. code-block:: python
 
-    # change the default xcorr function for all code in the with block
-    with set_xcorr(custom_normxcorr):
-        match_filter(['1'], [template], stream, .5, 'absolute', 1, False)
-        #  prints "calling custom xcorr function"
+    >>> # change the default xcorr function for all code in the with block
+    >>> with set_xcorr(custom_normxcorr):
+    ...     detections = match_filter(['1'], [template], stream, .5,
+    ...                               'absolute', 1, False) # doctest:+ELLIPSIS
+    calling custom xcorr function...
 
-    # permanently change the xcorr function (until the python kernel restarts)
-    set_xcorr(custom_normxcorr)
-    match_filter(['1'], [template], stream, .5, 'absolute', 1, False)
-    # prints "calling custom xcorr function
-    set_xcorr.revert()  # change it back to the previous state
+    >>> # permanently set the xcorr function (until the python kernel restarts)
+    >>> set_xcorr(custom_normxcorr)
+    >>> detections = match_filter(['1'], [template], stream, .5, 'absolute',
+    ...                           1, False) # doctest:+ELLIPSIS
+    calling custom xcorr function...
+    >>> set_xcorr.revert()  # change it back to the previous state

--- a/eqcorrscan/doc/submodules/utils.correlate.rst
+++ b/eqcorrscan/doc/submodules/utils.correlate.rst
@@ -134,6 +134,7 @@ or within the scope of a context manager:
 
     >>> # permanently set the xcorr function (until the python kernel restarts)
     >>> set_xcorr(custom_normxcorr)
+    default changed to custom_normxcorr
     >>> detections = match_filter(['1'], [template], stream, .5, 'absolute',
     ...                           1, False) # doctest:+ELLIPSIS
     calling custom xcorr function...

--- a/eqcorrscan/doc/submodules/utils.findpeaks.rst
+++ b/eqcorrscan/doc/submodules/utils.findpeaks.rst
@@ -14,6 +14,5 @@ findpeaks
 
        coin_trig
        find_peaks2_short
-       find_peaks_dep
 
     .. comment to end block

--- a/eqcorrscan/doc/tutorials/clustering.rst
+++ b/eqcorrscan/doc/tutorials/clustering.rst
@@ -18,30 +18,26 @@ threshold to 1,000km
 
 .. code-block:: python
 
-    from eqcorrscan.utils.clustering import space_cluster
-    from obspy.clients.fdsn import Client
-    from obspy import UTCDateTime
-    client = Client("IRIS")
-    starttime = UTCDateTime("2002-01-01")
-    endtime = UTCDateTime("2002-02-01")
-    cat = client.get_events(starttime=starttime, endtime=endtime,
-                            minmagnitude=6, catalog="ISC")
-    groups = space_cluster(catalog=cat, d_thresh=1000, show=False)
+    >>> from eqcorrscan.utils.clustering import space_cluster
+    >>> from obspy.clients.fdsn import Client
+    >>> from obspy import UTCDateTime
+
+    >>> client = Client("IRIS")
+    >>> starttime = UTCDateTime("2002-01-01")
+    >>> endtime = UTCDateTime("2002-02-01")
+    >>> cat = client.get_events(starttime=starttime, endtime=endtime,
+    ...                         minmagnitude=6, catalog="ISC")
+    >>> groups = space_cluster(catalog=cat, d_thresh=1000, show=False)
 
 Download a local catalog of earthquakes and cluster much finer (distance
 threshold of 2km).
 
 .. code-block:: python
 
-    from eqcorrscan.utils.clustering import space_cluster
-    from obspy.clients.fdsn import Client
-    from obspy import UTCDateTime
-    client = Client("NCEDC")
-    starttime = UTCDateTime("2002-01-01")
-    endtime = UTCDateTime("2002-02-01")
-    cat = client.get_events(starttime=starttime, endtime=endtime,
-                            minmagnitude=2)
-    groups = space_cluster(catalog=cat, d_thresh=2, show=False)
+    >>> client = Client("NCEDC")
+    >>> cat = client.get_events(starttime=starttime, endtime=endtime,
+    ...                         minmagnitude=2)
+    >>> groups = space_cluster(catalog=cat, d_thresh=2, show=False)
 
 
 Setting show to true will plot the dendrogram for grouping with individual
@@ -66,15 +62,11 @@ distance threshold and a one-day temporal limit.
 
 .. code-block:: python
 
-    from eqcorrscan.utils.clustering import space_time_cluster
-    from obspy.clients.fdsn import Client
-    from obspy import UTCDateTime
-    client = Client("IRIS")
-    starttime = UTCDateTime("2002-01-01")
-    endtime = UTCDateTime("2002-02-01")
-    cat = client.get_events(starttime=starttime, endtime=endtime,
-                            minmagnitude=6, catalog="ISC")
-    groups = space_time_cluster(catalog=cat, t_thresh=86400, d_thresh=1000)
+    >>> from eqcorrscan.utils.clustering import space_time_cluster
+    >>> client = Client("IRIS")
+    >>> cat = client.get_events(starttime=starttime, endtime=endtime,
+    ...                         minmagnitude=6, catalog="ISC")
+    >>> groups = space_time_cluster(catalog=cat, t_thresh=86400, d_thresh=1000)
 
 
 Cluster according to cross-correlation values
@@ -91,25 +83,32 @@ in the tests directory.
 
 .. code-block:: python
 
-    from obspy import read
-    import glob
-    import os
-    from eqcorrscan.utils.clustering import cluster
-    # You will need to edit this line to the location of your eqcorrscan repo.
-    testing_path = 'eqcorrscan/tests/test_data/similar_events'
-    stream_files = glob.glob(os.path.join(testing_path, '*'))
-    stream_list = [(read(stream_file), i)
-                   for i, stream_file in enumerate(stream_files)]
-    for stream in stream_list:
-        for tr in stream[0]:
-            if tr.stats.station not in ['WHAT2', 'WV04', 'GCSZ']:
-                stream[0].remove(tr)
-                continue
-            tr.detrend('simple')
-            tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
-            tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
-    groups = cluster(template_list=stream_list, show=False,
-                     corr_thresh=0.3)
+    >>> from obspy import read
+    >>> import glob
+    >>> import os
+    >>> from eqcorrscan.utils.clustering import cluster
+    >>> # You will need to edit this line to the location of your eqcorrscan repo.
+    >>> testing_path = 'eqcorrscan/tests/test_data/similar_events'
+    >>> stream_files = glob.glob(os.path.join(testing_path, '*'))
+    >>> stream_list = [(read(stream_file), i)
+    ...                for i, stream_file in enumerate(stream_files)]
+    >>> for stream in stream_list:
+    ...     for tr in stream[0]:
+    ...         if tr.stats.station not in ['WHAT2', 'WV04', 'GCSZ']:
+    ...             stream[0].remove(tr) # doctest:+ELLIPSIS
+    ...             continue
+    ...         tr = tr.detrend('simple')
+    ...         tr = tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
+    ...         tr = tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
+    <obspy.core.stream.Stream object at ...>
+    >>> groups = cluster(template_list=stream_list, show=False,
+    ...                  corr_thresh=0.3, cores=2)
+    Computing the distance matrix using 2 cores
+    Computing linkage
+    Clustering
+    Found 9 groups
+    Extracting and grouping
+
 
 Stack waveforms (linear)
 ------------------------
@@ -122,30 +121,12 @@ The following examples use the test data in the eqcorrscan github repository.
 
 .. code-block:: python
 
-    from obspy import read
-    import glob
-    import os
-    from eqcorrscan.utils.clustering import cluster
-    from eqcorrscan.utils.stacking import linstack
-    # You will need to edit this line to the location of your eqcorrscan repo.
-    testing_path = 'eqcorrscan/tests/test_data/similar_events'
-    stream_files = glob.glob(os.path.join(testing_path, '*'))
-    stream_list = [(read(stream_file), i)
-                   for i, stream_file in enumerate(stream_files)]
-    for stream in stream_list:
-        for tr in stream[0]:
-            if tr.stats.station not in ['WHAT2', 'WV04', 'GCSZ']:
-                stream[0].remove(tr)
-                continue
-            tr.detrend('simple')
-            tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
-            tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
-    groups = cluster(template_list=stream_list, show=False,
-                     corr_thresh=0.3)
-    # groups[0] should contain 3 streams, which we can now stack
-    # Groups are returned as lists of tuples, of the stream and event index
-    group_streams = [st_tuple[0] for st_tuple in groups[0]]
-    stack = linstack(streams=group_streams)
+    >>> from eqcorrscan.utils.stacking import linstack
+
+    >>> # groups[0] should contain 3 streams, which we can now stack
+    >>> # Groups are returned as lists of tuples, of the stream and event index
+    >>> group_streams = [st_tuple[0] for st_tuple in groups[0]]
+    >>> stack = linstack(streams=group_streams)
 
 
 
@@ -162,27 +143,10 @@ of the instantaneous phase.  In this manor coherent signals are amplified.
 
 .. code-block:: python
 
-    from obspy import read
-    import glob
-    import os
-    from eqcorrscan.utils.clustering import cluster
-    from eqcorrscan.utils.stacking import PWS_stack
-    # You will need to edit this line to the location of your eqcorrscan repo.
-    testing_path = 'eqcorrscan/tests/test_data/similar_events'
-    stream_files = glob.glob(os.path.join(testing_path, '*'))
-    stream_list = [(read(stream_file), i)
-                   for i, stream_file in enumerate(stream_files)]
-    for stream in stream_list:
-        for tr in stream[0]:
-            if tr.stats.station not in ['WHAT2', 'WV04', 'GCSZ']:
-                stream[0].remove(tr)
-                continue
-            tr.detrend('simple')
-            tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
-            tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
-    groups = cluster(template_list=stream_list, show=False,
-                     corr_thresh=0.3)
-    # groups[0] should contain 3 streams, which we can now stack
-    # Groups are returned as lists of tuples, of the stream and event index
-    group_streams = [st_tuple[0] for st_tuple in groups[0]]
-    stack = PWS_stack(streams=group_streams)
+    >>> from eqcorrscan.utils.stacking import PWS_stack
+
+    >>> # groups[0] should contain 3 streams, which we can now stack
+    >>> # Groups are returned as lists of tuples, of the stream and event index
+    >>> stack = PWS_stack(streams=group_streams)
+    Computing instantaneous phase
+    Computing the phase stack

--- a/eqcorrscan/doc/tutorials/mag-calc.rst
+++ b/eqcorrscan/doc/tutorials/mag-calc.rst
@@ -15,18 +15,19 @@ This example requires data downloaded from the eqcorrscan github repository.
 
 .. code-block:: python
 
-    from eqcorrscan.utils.mag_calc import amp_pick_sfile
-    from obspy.core.event import Event
-    import os
-    testing_path = 'eqcorrscan/tests/test_data'
-    sfile = os.path.join(testing_path, 'REA', 'TEST_',
-                         '01-0411-15L.S201309')
-    datapath = os.path.join(testing_path, 'WAV', 'TEST_')
-    respdir = testing_path
-    event = amp_pick_sfile(sfile=sfile, datapath=datapath,
-                           respdir=respdir, chans=['Z'], var_wintype=True,
-                           winlen=0.9, pre_pick=0.2, pre_filt=True,
-                           lowcut=1.0, highcut=20.0, corners=4)
+    >>> from eqcorrscan.utils.mag_calc import amp_pick_sfile
+    >>> from obspy.core.event import Event
+    >>> import os
+    >>> testing_path = 'eqcorrscan/tests/test_data'
+    >>> sfile = os.path.join(testing_path, 'REA', 'TEST_',
+    ...                      '01-0411-15L.S201309')
+    >>> datapath = os.path.join(testing_path, 'WAV', 'TEST_')
+    >>> respdir = testing_path
+    >>> event = amp_pick_sfile(sfile=sfile, datapath=datapath,
+    ...                        respdir=respdir, chans=['Z'], var_wintype=True,
+    ...                        winlen=0.9, pre_pick=0.2, pre_filt=True,
+    ...                        lowcut=1.0, highcut=20.0, corners=4) # doctest:+ELLIPSIS
+    Working on ...
 
 Relative moment by singular-value decomposition
 -----------------------------------------------
@@ -41,32 +42,33 @@ This example requires data downloaded from the eqcorrscan github repository.
 
 .. code-block:: python
 
-    from eqcorrscan.utils.mag_calc import SVD_moments
-    from obspy import read
-    import glob
-    import os
-    from eqcorrscan.utils.clustering import SVD
-    import numpy as np
-    # Do the set-up
-    testing_path = 'eqcorrscan/tests/test_data/similar_events'
-    stream_files = glob.glob(os.path.join(testing_path, '*'))
-    stream_list = [read(stream_file) for stream_file in stream_files]
-    event_list = []
-    for i, stream in enumerate(stream_list):
-        st_list = []
-        for tr in stream:
-            # Only use the vertical channels of sites with known high similarity.
-            # You do not need to use this step for your data.
-            if (tr.stats.station, tr.stats.channel) not in\
-                    [('WHAT2', 'SH1'), ('WV04', 'SHZ'), ('GCSZ', 'EHZ')]:
-                stream.remove(tr)
-                continue
-            tr.detrend('simple')
-            tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
-            tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
-            st_list.append(i)
-        event_list.append(st_list)
-    event_list = np.asarray(event_list).T.tolist()
-    SVectors, SValues, Uvectors, stachans = SVD(stream_list=stream_list)
-    M, events_out = SVD_moments(U=Uvectors, s=SValues, V=SVectors,
-                                stachans=stachans, event_list=event_list)
+    >>> from eqcorrscan.utils.mag_calc import svd_moments
+    >>> from obspy import read
+    >>> import glob
+    >>> from eqcorrscan.utils.clustering import svd
+    >>> import numpy as np
+    >>> # Do the set-up
+    >>> testing_path = 'eqcorrscan/tests/test_data/similar_events'
+    >>> stream_files = glob.glob(os.path.join(testing_path, '*'))
+    >>> stream_list = [read(stream_file) for stream_file in stream_files]
+    >>> event_list = []
+    >>> for i, stream in enumerate(stream_list): # doctest:+ELLIPSIS
+    ...     st_list = []
+    ...     for tr in stream:
+    ...         # Only use the vertical channels of sites with known high similarity.
+    ...         # You do not need to use this step for your data.
+    ...         if (tr.stats.station, tr.stats.channel) not in\
+    ...                 [('WHAT2', 'SH1'), ('WV04', 'SHZ'), ('GCSZ', 'EHZ')]:
+    ...             stream.remove(tr)
+    ...             continue
+    ...         tr.detrend('simple')
+    ...         tr.filter('bandpass', freqmin=5.0, freqmax=15.0)
+    ...         tr.trim(tr.stats.starttime + 40, tr.stats.endtime - 45)
+    ...         st_list.append(i)
+    ...     event_list.append(st_list)
+    <obspy.core.stream.Stream object at ...>
+    >>> event_list = np.asarray(event_list).T.tolist()
+    >>> SVectors, SValues, Uvectors, stachans = svd(stream_list=stream_list)
+    >>> M, events_out = svd_moments(u=Uvectors, s=SValues, v=SVectors,
+    ...                             stachans=stachans, event_list=event_list) # doctest:+ELLIPSIS
+    Created Kernel matrix: ...

--- a/eqcorrscan/doc/tutorials/matched-filter.rst
+++ b/eqcorrscan/doc/tutorials/matched-filter.rst
@@ -64,14 +64,14 @@ event:
 
 .. code-block:: python
 
-     import glob
-     from eqcorrscan.core.match_filter import Template
-     sac_files = glob.glob('eqcorrscan/tests/test_data/SAC/2014p611252')
-     # sac_files is now a list of all the SAC files for event id:2014p611252
-     template = Template().construct(
-          method='from_sac', name='test', lowcut=2.0, highcut=8.0,
-          samp_rate=20.0, filt_order=4, prepick=0.1, swin='all',
-          length=2.0, sac_files=sac_files)
+     >>> import glob
+     >>> from eqcorrscan.core.match_filter import Template
+     >>> sac_files = glob.glob('eqcorrscan/tests/test_data/SAC/2014p611252/*')
+     >>> # sac_files is now a list of all the SAC files for event id:2014p611252
+     >>> template = Template().construct(
+     ...      method='from_sac', name='test', lowcut=2.0, highcut=8.0,
+     ...      samp_rate=20.0, filt_order=4, prepick=0.1, swin='all',
+     ...      length=2.0, sac_files=sac_files)
 
 
 Tribe creation
@@ -84,19 +84,20 @@ to their start-time, but you can rename them later if you wish:
 
 .. code-block:: python
 
-     from eqcorrscan.core.match_filter import Tribe
-     from obspy.clients.fdsn import Client
+     >>> from eqcorrscan.core.match_filter import Tribe
+     >>> from obspy.clients.fdsn import Client
 
-     client = Client('NCEDC')
-     catalog = client.get_events(eventid='72572665', includearrivals=True)
-     # To speed the example we have a catalog of one event, but you can have
-     # more, we are also only using the first five picks, again to speed the
-     # example.
-     catalog[0].picks = catalog[0].picks[0:5]
-     tribe = Tribe().construct(
-          method='from_client', catalog=catalog, client_id='NCEDC', lowcut=2.0,
-          highcut=8.0,  samp_rate=20.0, filt_order=4, length=6.0, prepick=0.1,
-          swin='all', process_len=3600, all_horiz=True)
+     >>> client = Client('NCEDC')
+     >>> catalog = client.get_events(eventid='72572665', includearrivals=True)
+     >>> # To speed the example we have a catalog of one event, but you can have
+     >>> # more, we are also only using the first five picks, again to speed the
+     >>> # example.
+     >>> catalog[0].picks = catalog[0].picks[0:5]
+     >>> tribe = Tribe().construct(
+     ...      method='from_client', catalog=catalog, client_id='NCEDC', lowcut=2.0,
+     ...      highcut=8.0,  samp_rate=20.0, filt_order=4, length=6.0, prepick=0.1,
+     ...      swin='all', process_len=3600, all_horiz=True)
+     Pre-processing data
 
 Matched-filter detection using a Tribe
 --------------------------------------
@@ -115,12 +116,12 @@ data by running the following:
 
 .. code-block:: python
 
-     from obspy import UTCDateTime
+     >>> from obspy import UTCDateTime
 
-     party, stream = tribe.client_detect(
-          client=client, starttime=UTCDateTime(2016, 1, 2),
-          endtime=UTCDateTime(2016, 1, 3), threshold=8, threshold_type='MAD',
-          trig_int=6, plotvar=False, return_stream=True)
+     >>> party, stream = tribe.client_detect(
+     ...      client=client, starttime=UTCDateTime(2016, 1, 2),
+     ...      endtime=UTCDateTime(2016, 1, 3), threshold=8, threshold_type='MAD',
+     ...      trig_int=6, plotvar=False, return_stream=True)
 
 Lag-calc using a Party
 ----------------------
@@ -130,8 +131,10 @@ generate re-picked catalogues using lag-calc:
 
 .. code-block:: python
 
-     repicked_catalog = party.lag_calc(
-          stream, pre_processed=False, shift_len=0.2, min_cc=0.4)
+     >>> stream = stream.merge().sort(['station'])
+     >>> repicked_catalog = party.lag_calc(stream, pre_processed=False,
+     ...                                   shift_len=0.2, min_cc=0.4) # doctest:+ELLIPSIS
+     5 Trace(s) in Stream:...
 
 By using the above examples you can go from a standard catalog available from
 data centers, to a matched-filter detected and cross-correlation repicked

--- a/eqcorrscan/doc/tutorials/subspace.rst
+++ b/eqcorrscan/doc/tutorials/subspace.rst
@@ -44,8 +44,8 @@ To begin with you will need to create a **Detector**:
 
 .. code-block:: python
 
-    from eqcorrscan.core import subspace
-    detector = subspace.Detector()
+    >>> from eqcorrscan.core import subspace
+    >>> detector = subspace.Detector()
 
 This will create an empty *detector* object.  These objects have various attributes,
 including the data to be used as a detector (*detector.data*), alongside the full
@@ -62,9 +62,19 @@ aligned (see clustering submodule for alignment methods).
 
 .. code-block:: python
 
-    detector.construct(streams=streams, lowcut=2, highcut=9, filt_order=4,
-                       sampling_rate=20, multiplex=True, name='Test_1',
-                       align=True, shift_len=0.5)
+    >>> from obspy import read
+    >>> import glob
+    >>> wavefiles = glob.glob('eqcorrscan/tests/test_data/similar_events/*')
+    >>> streams = [read(w) for w in wavefiles[0:3]]
+    >>> # Channels must all be the same length
+    >>> for st in streams:
+    ...    for tr in st:
+    ...       tr.data = tr.data[int(41.5 * tr.stats.sampling_rate):
+    ...                         int(44 * tr.stats.sampling_rate)]
+    >>> detector.construct(streams=streams, lowcut=2, highcut=9, filt_order=4,
+    ...                    sampling_rate=20, multiplex=True, name='Test_1',
+    ...                    align=True, shift_len=0.5, reject=0.2)
+    Detector: Test_1
 
 This will populate all the attributes of your *detector* object, and fill the
 *detector.data* with the full input basis vector matrix.
@@ -76,7 +86,8 @@ EQcorrscan simply use the *partition* method:
 
 .. code-block:: python
 
-    detector.partition(4)
+    >>> detector.partition(2)
+    Detector: Test_1
 
 This will populate *detector.data* with the first four, left-most input basis
 vectors.  You can test to see how much of your original design set is
@@ -84,7 +95,7 @@ described by this detector by using the *energy_capture* method:
 
 .. code-block:: python
 
-    percent_capture = detector.energy_capture()
+    >>> percent_capture = detector.energy_capture()
 
 This will return a percentage capture, you can run this for multiple dimensions
 to test what dimension best suits your application.  Again, details for this
@@ -99,7 +110,12 @@ True.
 
 .. code-block:: python
 
-    detections = detector.detect(st=stream, threshold=0.5, trig_int=3)
+    >>> stream = read(wavefiles[0])
+    >>> for tr in stream:
+    ...   tr.data = tr.data[int(41.5 * tr.stats.sampling_rate):
+    ...                     int(44 * tr.stats.sampling_rate)]
+    >>> detections = detector.detect(st=stream, threshold=0.5, trig_int=3) # doctest:+ELLIPSIS
+    Detection took ...
 
 
 Advanced Example

--- a/eqcorrscan/doc/tutorials/template-creation.rst
+++ b/eqcorrscan/doc/tutorials/template-creation.rst
@@ -1,6 +1,10 @@
 Template creation
 =================
 
+Note: These tutorials are for the functional workflow - for details on creating
+Template and Tribe objects see the :doc:`matched filter <matched-filter>` docs
+page.
+
 Simple example
 --------------
 
@@ -18,15 +22,16 @@ FDSN (see |obspy_fdsn| for a list of possible clients):
 
 .. code-block:: python
 
-    from obspy.clients.fdsn import Client
-    from obspy.core.event import Catalog
-    from eqcorrscan.core.template_gen import from_client
-    client = Client('NCEDC')
-    catalog = client.get_events(eventid='72572665', includearrivals=True)
-    templates = from_client(catalog=catalog, client_id='NCEDC',
-                            lowcut=2.0, highcut=9.0, samp_rate=20.0,
-                            filt_order=4, length=3.0, prepick=0.15,
-                            swin='all', process_len=200)
+    >>> from obspy.clients.fdsn import Client
+    >>> from obspy.core.event import Catalog
+    >>> from eqcorrscan.core.template_gen import from_client
+    >>> client = Client('NCEDC')
+    >>> catalog = client.get_events(eventid='72572665', includearrivals=True)
+    >>> templates = from_client(catalog=catalog, client_id='NCEDC',
+    ...                         lowcut=2.0, highcut=9.0, samp_rate=20.0,
+    ...                         filt_order=4, length=3.0, prepick=0.15,
+    ...                         swin='all', process_len=200)
+    Pre-processing data
 
 This will download data for a single event (given by eventid) from the NCEDC
 database, then use that information to download relevant waveform data.  These
@@ -77,7 +82,7 @@ which is useful for template storage.  However we do not constrain you to this.
 
 .. code-block:: python
 
-    template.write('template.ms', format="MSEED")
+    >>> templates[0].write('template.ms', format="MSEED")
 
 
 Advanced example

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -96,7 +96,11 @@ class _Context:
 
     def __repr__(self):
         """ this hides the fact _Context instance are returned after calls """
-        return None
+        name = self.cache[self.value_to_switch].__str__()
+        if hasattr(self.cache[self.value_to_switch], '__name__'):
+            name = self.cache[self.value_to_switch].__name__
+        out_str = ("%s changed to %s" % (self.value_to_switch, name))
+        return out_str
 
     def revert(self):
         """ revert the default xcorr function to previous value """

--- a/eqcorrscan/utils/mag_calc.py
+++ b/eqcorrscan/utils/mag_calc.py
@@ -1106,7 +1106,7 @@ def svd_moments(u, s, v, stachans, event_list, n_svs=2):
     K_width = len(K[0])
     # Add an extra row to K, so average moment = 1
     K.append(np.ones(K_width) * (1. / K_width))
-    print("\nCreated Kernel matrix: ")
+    print("Created Kernel matrix: ")
     del row
     print('\n'.join([''.join([str(round(float(item), 3)).ljust(6)
           for item in row]) for row in K]))


### PR DESCRIPTION
Fixes #142 

This pull request reformats the appropriate doc-strings so that py.test will find them and run them.  I have set it up so that these get run on circleci, some are slow (network) tests, so running them there should result in less slow-don for other ci services.

I will need to build the docs on readthedocs and check that everything renders properly:
- [x] tutorials
- [x] utils.correlate