### PR TITLE
use _isnan and test on MSCV 14

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
-## Current
+## 0.2.7
+* Patch multi_corr.c to work with more versions of MSVC
+
+
+## 0.2.6
 * Added the ability to change the correlation functions used in detection
   methods through the parameter xcorr_func of match_filter, Template.detect
   and Tribe.detect, or using the set_xcorr context manager in

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,13 +9,13 @@ environment:
     PR_URL: "--pr-url https://github.com/%APPVEYOR_REPO_NAME%/pull/%APPVEYOR_PULL_REQUEST_NUMBER%"
 
   matrix:
-    - PYTHON: "C:\\Miniconda-x64"
+    - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
-    - PYTHON: "C:\\Miniconda-x86"
+    - PYTHON: "C:\\Miniconda35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "86"
-    - PYTHON: "C:\\Miniconda-x64"
+    - PYTHON: "C:\\Miniconda27-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,10 +3,6 @@
 # AppVeyor.com is a Continuous Integration service to build and run tests under Windows
 environment:
   global:
-    # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
-    # /E:ON and /V:ON options are not enabled in the batch script intepreter
-    # See: https://stackoverflow.com/a/13751649
-    CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\misc\\appveyor\\run_with_env.cmd"
     PYTHON: "C:\\conda"
     MINICONDA_VERSION: "3.7.0"
     CI_URL: "--ci-url https://ci.appveyor.com/project/%APPVEYOR_REPO_NAME%/build/1.0.%APPVEYOR_BUILD_NUMBER%-%APPVEYOR_REPO_BRANCH%"
@@ -16,9 +12,16 @@ environment:
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda-x86"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "86"
     - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
+      # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
+      # /E:ON and /V:ON options are not enabled in the batch script intepreter
+      # See: https://stackoverflow.com/a/13751649
+      CMD_IN_ENV: "cmd /E:ON /V:ON /C .\\misc\\appveyor\\run_with_env.cmd"
 
 install:
   - '.\\misc\\appveyor\\trim_path.bat'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,7 +15,7 @@ environment:
     - PYTHON: "C:\\Miniconda35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "86"
-    - PYTHON: "C:\\Miniconda27-x64"
+    - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,9 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Miniconda-x64"
+      PYTHON_VERSION: "3.5"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
 

--- a/eqcorrscan/lib/multi_corr.c
+++ b/eqcorrscan/lib/multi_corr.c
@@ -23,10 +23,8 @@
 #include <string.h>
 #include <math.h>
 #if (defined(_MSC_VER))
-    #if (_MSC_VER < 1800)
-        #include <float.h>
-        #define isnanf(x) _isnanf(x)
-    #endif
+    #include <float.h>
+    #define isnanf(x) _isnan(x)
     #define inline __inline
 #endif
 #if (defined(__APPLE__) && !isnanf)


### PR DESCRIPTION
This should patch multi_corr.c to use a more available nan checker.  This should also run tests using multiple compilers on Windows now.

**This will require a 0.2.7 patch release.**

As such, on merge #160 needs to be re-rendered to 0.2.7 and everything done again.