### PR TITLE
Use floats instead of doubles

### DIFF
--- a/eqcorrscan/lib/multi_corr.c
+++ b/eqcorrscan/lib/multi_corr.c
@@ -45,10 +45,12 @@ int normxcorr_fftw(float*, int, int, float*, int, float*, int, int*, int*);
 
 static inline int set_ncc(int t, int i, int template_len, int image_len, float value, int *used_chans, int *pad_array, float *ncc);
 
-int normxcorr_fftw_main(float*, int, int, float*, int, float*, int, double*, double*, double*,
-        fftw_complex*, fftw_complex*, fftw_complex*, fftw_plan, fftw_plan, fftw_plan, int*, int*);
+int normxcorr_fftw_main(float*, int, int, float*, int, float*, int, float*, float*, float*,
+        fftwf_complex*, fftwf_complex*, fftwf_complex*, fftwf_plan, fftwf_plan, fftwf_plan, int*, int*);
 
 int normxcorr_fftw_threaded(float*, int, int, float*, int, float*, int, int*, int*);
+
+void free_fftwf_arrays(int, float**, float**, float**, fftwf_complex**, fftwf_complex**, fftwf_complex**);
 
 void free_fftw_arrays(int, double**, double**, double**, fftw_complex**, fftw_complex**, fftw_complex**);
 
@@ -75,42 +77,42 @@ int normxcorr_fftw_threaded(float *templates, int template_len, int n_templates,
 	int N2 = fft_len / 2 + 1;
 	int i, t, startind, status = 0;
 	double mean, stdev, old_mean, new_samp, old_samp, var=0.0, sum=0.0, acceptedDiff = 0.0000001;
-	double * norm_sums = (double *) calloc(n_templates, sizeof(double));
-	double * template_ext = (double *) calloc(fft_len * n_templates, sizeof(double));
-	double * image_ext = (double *) calloc(fft_len, sizeof(double));
-	double * ccc = (double *) fftw_malloc(sizeof(double) * fft_len * n_templates);
-	fftw_complex * outa = (fftw_complex *) fftw_malloc(sizeof(fftw_complex) * N2 * n_templates);
-	fftw_complex * outb = (fftw_complex *) fftw_malloc(sizeof(fftw_complex) * N2);
-	fftw_complex * out = (fftw_complex *) fftw_malloc(sizeof(fftw_complex) * N2 * n_templates);
+	float * norm_sums = (float *) calloc(n_templates, sizeof(float));
+	float * template_ext = (float *) calloc(fft_len * n_templates, sizeof(float));
+	float * image_ext = (float *) calloc(fft_len, sizeof(float));
+	float * ccc = (float *) fftwf_malloc(sizeof(float) * fft_len * n_templates);
+	fftwf_complex * outa = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex) * N2 * n_templates);
+	fftwf_complex * outb = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex) * N2);
+	fftwf_complex * out = (fftwf_complex *) fftwf_malloc(sizeof(fftwf_complex) * N2 * n_templates);
 	// Initialize threads
 	#ifdef N_THREADS
-        fftw_init_threads();
-	    fftw_plan_with_nthreads(N_THREADS);
+        fftwf_init_threads();
+	    fftwf_plan_with_nthreads(N_THREADS);
 	#endif
 	// Plan
 
-	fftw_plan pa = fftw_plan_dft_r2c_2d(n_templates, fft_len, template_ext, outa, FFTW_ESTIMATE);
-	fftw_plan pb = fftw_plan_dft_r2c_1d(fft_len, image_ext, outb, FFTW_ESTIMATE);
-	fftw_plan px = fftw_plan_dft_c2r_2d(n_templates, fft_len, out, ccc, FFTW_ESTIMATE);
+	fftwf_plan pa = fftwf_plan_dft_r2c_2d(n_templates, fft_len, template_ext, outa, FFTW_ESTIMATE);
+	fftwf_plan pb = fftwf_plan_dft_r2c_1d(fft_len, image_ext, outb, FFTW_ESTIMATE);
+	fftwf_plan px = fftwf_plan_dft_c2r_2d(n_templates, fft_len, out, ccc, FFTW_ESTIMATE);
 
 	// zero padding - and flip template
 	for (t = 0; t < n_templates; ++t){
 		for (i = 0; i < template_len; ++i)
 		{
-			template_ext[(t * fft_len) + i] = (double) templates[((t + 1) * template_len) - (i + 1)];
+			template_ext[(t * fft_len) + i] = templates[((t + 1) * template_len) - (i + 1)];
 			norm_sums[t] += templates[(t * template_len) + i];
 		}
 	}
 	for (i = 0; i < image_len; ++i)
 	{
-		image_ext[i] = (double) image[i];
+		image_ext[i] = image[i];
 	}
 	//  Compute ffts of template and image
 	#pragma omp parallel sections
 	{
-	    {fftw_execute(pa); }
+	    {fftwf_execute(pa); }
 	    #pragma omp section
-	    {fftw_execute(pb); }
+	    {fftwf_execute(pb); }
 	}
 	//  Compute dot product
 	for (t = 0; t < n_templates; ++t){
@@ -121,24 +123,24 @@ int normxcorr_fftw_threaded(float *templates, int template_len, int n_templates,
     	}
     }
 	//  Compute inverse fft
-	fftw_execute(px);
+	fftwf_execute(px);
 	//  Procedures for normalisation
 	// Compute starting mean, will update this
 	for (i=0; i < template_len; ++i){
-		sum += image[i];
+		sum += (double) image[i];
 	}
 	mean = sum / template_len;
 
 	// Compute starting standard deviation
 	for (i=0; i < template_len; ++i){
-		var += pow(image[i] - mean, 2) / (template_len);
+		var += pow((double) image[i] - mean, 2) / (template_len);
 	}
 	stdev = sqrt(var);
     // Used for centering - taking only the valid part of the cross-correlation
 	startind = template_len - 1;
     if (var >= acceptedDiff) {
         for (t = 0; t < n_templates; ++t){
-            double c = ((ccc[(t * fft_len) + startind] / (fft_len * n_templates)) - norm_sums[t] * mean) / stdev;
+            float c = ((ccc[(t * fft_len) + startind] / (fft_len * n_templates)) - norm_sums[t] * mean) / stdev;
             status += set_ncc(t, 0, template_len, image_len, (float) c, used_chans, pad_array, ncc);
         }
     }
@@ -146,31 +148,31 @@ int normxcorr_fftw_threaded(float *templates, int template_len, int n_templates,
 	for(i = 1; i < (image_len - template_len + 1); ++i){
 		// Need to cast to double otherwise we end up with annoying floating
 		// point errors when the variance is massive - collecting fp errors.
-		new_samp = image[i + template_len - 1];
-		old_samp = image[i - 1];
+		new_samp = (double) image[i + template_len - 1];
+		old_samp = (double) image[i - 1];
 		old_mean = mean;
 		mean = mean + (new_samp - old_samp) / template_len;
 		var += (new_samp - old_samp) * (new_samp - mean + old_samp - old_mean) / (template_len);
 		stdev = sqrt(var);
-        if (var > acceptedDiff) { // TODO: above is '>=', should they be the same?
+        if (var >= acceptedDiff) { // TODO: above is '>=', should they be the same?
             for (t = 0; t < n_templates; ++t){
-                double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
+                float c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
                 status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
 			}
 		}
 	}
 	//  Clean up
-	fftw_destroy_plan(pa);
-	fftw_destroy_plan(pb);
-	fftw_destroy_plan(px);
+	fftwf_destroy_plan(pa);
+	fftwf_destroy_plan(pb);
+	fftwf_destroy_plan(px);
 
-	fftw_free(out);
-	fftw_free(outa);
-	fftw_free(outb);
-	fftw_free(ccc);
+	fftwf_free(out);
+	fftwf_free(outa);
+	fftwf_free(outb);
+	fftwf_free(ccc);
 
-	fftw_cleanup();
-	fftw_cleanup_threads();
+	fftwf_cleanup();
+	fftwf_cleanup_threads();
 
 	free(template_ext);
 	free(image_ext);
@@ -203,20 +205,20 @@ int normxcorr_fftw(float *templates, int template_len, int n_templates,
 	int status = 0;
 	int N2 = fft_len / 2 + 1;
 	// All memory allocated with `fftw_malloc` to ensure 16-byte aligned
-	double * template_ext = fftw_alloc_real(fft_len * n_templates);
-	double * image_ext = fftw_alloc_real(fft_len);
-	double * ccc = fftw_alloc_real(fft_len * n_templates);
-	fftw_complex * outa = fftw_alloc_complex(N2 * n_templates);
-	fftw_complex * outb = fftw_alloc_complex(N2);
-	fftw_complex * out = fftw_alloc_complex(N2 * n_templates);
+	float * template_ext = fftwf_alloc_real(fft_len * n_templates);
+	float * image_ext = fftwf_alloc_real(fft_len);
+	float * ccc = fftwf_alloc_real(fft_len * n_templates);
+	fftwf_complex * outa = fftwf_alloc_complex(N2 * n_templates);
+	fftwf_complex * outb = fftwf_alloc_complex(N2);
+	fftwf_complex * out = fftwf_alloc_complex(N2 * n_templates);
 	// Plan
-	fftw_plan pa = fftw_plan_dft_r2c_2d(n_templates, fft_len, template_ext, outa, FFTW_ESTIMATE);
-	fftw_plan pb = fftw_plan_dft_r2c_1d(fft_len, image_ext, outb, FFTW_ESTIMATE);
-	fftw_plan px = fftw_plan_dft_c2r_2d(n_templates, fft_len, out, ccc, FFTW_ESTIMATE);
+	fftwf_plan pa = fftwf_plan_dft_r2c_2d(n_templates, fft_len, template_ext, outa, FFTW_ESTIMATE);
+	fftwf_plan pb = fftwf_plan_dft_r2c_1d(fft_len, image_ext, outb, FFTW_ESTIMATE);
+	fftwf_plan px = fftwf_plan_dft_c2r_2d(n_templates, fft_len, out, ccc, FFTW_ESTIMATE);
 
 	// Initialise to zero
-	memset(template_ext, 0, fft_len * n_templates * sizeof(double));
-	memset(image_ext, 0, fft_len * sizeof(double));
+	memset(template_ext, 0, fft_len * n_templates * sizeof(float));
+	memset(image_ext, 0, fft_len * sizeof(float));
 
 	// Call the function to do the work
 	status = normxcorr_fftw_main(templates, template_len, n_templates, image, image_len,
@@ -224,19 +226,19 @@ int normxcorr_fftw(float *templates, int template_len, int n_templates,
             used_chans, pad_array);
 
 	// free memory and plans
-	fftw_destroy_plan(pa);
-	fftw_destroy_plan(pb);
-	fftw_destroy_plan(px);
+	fftwf_destroy_plan(pa);
+	fftwf_destroy_plan(pb);
+	fftwf_destroy_plan(px);
 
-	fftw_free(out);
-	fftw_free(outa);
-	fftw_free(outb);
-	fftw_free(ccc);
-	fftw_free(template_ext);
-	fftw_free(image_ext);
+	fftwf_free(out);
+	fftwf_free(outa);
+	fftwf_free(outb);
+	fftwf_free(ccc);
+	fftwf_free(template_ext);
+	fftwf_free(image_ext);
 
-	fftw_cleanup();
-	fftw_cleanup_threads();
+	fftwf_cleanup();
+	fftwf_cleanup_threads();
 
 	return status;
 }
@@ -244,9 +246,9 @@ int normxcorr_fftw(float *templates, int template_len, int n_templates,
 
 int normxcorr_fftw_main(float *templates, int template_len, int n_templates,
                         float *image, int image_len, float *ncc, int fft_len,
-                        double *template_ext, double *image_ext, double *ccc,
-                        fftw_complex *outa, fftw_complex *outb, fftw_complex *out,
-                        fftw_plan pa, fftw_plan pb, fftw_plan px, int *used_chans,
+                        float *template_ext, float *image_ext, float *ccc,
+                        fftwf_complex *outa, fftwf_complex *outb, fftwf_complex *out,
+                        fftwf_plan pa, fftwf_plan pb, fftwf_plan px, int *used_chans,
                         int *pad_array) {
   /*
   Purpose: compute frequency domain normalised cross-correlation of real data using fftw
@@ -276,23 +278,23 @@ int normxcorr_fftw_main(float *templates, int template_len, int n_templates,
 	int N2 = fft_len / 2 + 1;
 	int i, t, startind, status = 0;
 	double mean, stdev, old_mean, new_samp, old_samp, var=0.0, sum=0.0, acceptedDiff = 0.0000001;
-	double * norm_sums = (double *) calloc(n_templates, sizeof(double));
+	float * norm_sums = (float *) calloc(n_templates, sizeof(float));
 
 	// zero padding - and flip template
 	for (t = 0; t < n_templates; ++t){
 		for (i = 0; i < template_len; ++i)
 		{
-			template_ext[(t * fft_len) + i] = (double) templates[((t + 1) * template_len) - (i + 1)];
+			template_ext[(t * fft_len) + i] = templates[((t + 1) * template_len) - (i + 1)];
 			norm_sums[t] += templates[(t * template_len) + i];
 		}
 	}
 	for (i = 0; i < image_len; ++i)
 	{
-		image_ext[i] = (double) image[i];
+		image_ext[i] = image[i];
 	}
 	//  Compute ffts of template and image
-	fftw_execute_dft_r2c(pa, template_ext, outa);
-	fftw_execute_dft_r2c(pb, image_ext, outb);
+	fftwf_execute_dft_r2c(pa, template_ext, outa);
+	fftwf_execute_dft_r2c(pb, image_ext, outb);
 
 	//  Compute dot product
 	for (t = 0; t < n_templates; ++t){
@@ -303,18 +305,18 @@ int normxcorr_fftw_main(float *templates, int template_len, int n_templates,
     	}
     }
 	//  Compute inverse fft
-	fftw_execute_dft_c2r(px, out, ccc);
+	fftwf_execute_dft_c2r(px, out, ccc);
 
 	//  Procedures for normalisation
 	// Compute starting mean, will update this
 	for (i=0; i < template_len; ++i){
-		sum += image[i];
+		sum += (double) image[i];
 	}
 	mean = sum / template_len;
 
 	// Compute starting standard deviation
 	for (i=0; i < template_len; ++i){
-		var += pow(image[i] - mean, 2) / (template_len);
+		var += pow((double) image[i] - mean, 2) / (template_len);
 	}
 	stdev = sqrt(var);
 
@@ -323,7 +325,7 @@ int normxcorr_fftw_main(float *templates, int template_len, int n_templates,
 	startind = template_len - 1;
     if (var >= acceptedDiff) {
         for (t = 0; t < n_templates; ++t){
-            double c = ((ccc[(t * fft_len) + startind] / (fft_len * n_templates)) - norm_sums[t] * mean) / stdev;
+            float c = ((ccc[(t * fft_len) + startind] / (fft_len * n_templates)) - norm_sums[t] * mean) / stdev;
             status += set_ncc(t, 0, template_len, image_len, (float) c, used_chans, pad_array, ncc);
         }
     }
@@ -332,15 +334,15 @@ int normxcorr_fftw_main(float *templates, int template_len, int n_templates,
 	for(i = 1; i < (image_len - template_len + 1); ++i){
 		// Need to cast to double otherwise we end up with annoying floating
 		// point errors when the variance is massive - collecting fp errors.
-		new_samp = image[i + template_len - 1];
-		old_samp = image[i - 1];
+		new_samp = (double) image[i + template_len - 1];
+		old_samp = (double) image[i - 1];
 		old_mean = mean;
 		mean = mean + (new_samp - old_samp) / template_len;
 		var += (new_samp - old_samp) * (new_samp - mean + old_samp - old_mean) / (template_len);
 		stdev = sqrt(var);
-        if (var > acceptedDiff) { // TODO: above is '>=', should they be the same?
+        if (var >= acceptedDiff) {
             for (t = 0; t < n_templates; ++t){
-                double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
+                float c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
                 status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
 			}
 		}
@@ -380,6 +382,26 @@ static inline int set_ncc(int t, int i, int template_len, int image_len, float v
     return status;
 }
 
+void free_fftwf_arrays(int size, float **template_ext, float **image_ext, float **ccc,
+        fftwf_complex **outa, fftwf_complex **outb, fftwf_complex **out) {
+    int i;
+
+    /* free memory */
+    for (i = 0; i < size; i++) {
+        fftwf_free(template_ext[i]);
+        fftwf_free(image_ext[i]);
+        fftwf_free(ccc[i]);
+        fftwf_free(outa[i]);
+        fftwf_free(outb[i]);
+        fftwf_free(out[i]);
+    }
+    free(template_ext);
+    free(image_ext);
+    free(ccc);
+    free(outa);
+    free(outb);
+    free(out);
+}
 
 void free_fftw_arrays(int size, double **template_ext, double **image_ext, double **ccc,
         fftw_complex **outa, fftw_complex **outb, fftw_complex **out) {
@@ -408,13 +430,13 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
     int i;
     int r = 0;
     size_t N2 = (size_t) fft_len / 2 + 1;
-    double **template_ext = NULL;
-    double **image_ext = NULL;
-    double **ccc = NULL;
-    fftw_complex **outa = NULL;
-    fftw_complex **outb = NULL;
-    fftw_complex **out = NULL;
-    fftw_plan pa, pb, px;
+    float **template_ext = NULL;
+    float **image_ext = NULL;
+    float **ccc = NULL;
+    fftwf_complex **outa = NULL;
+    fftwf_complex **outb = NULL;
+    fftwf_complex **out = NULL;
+    fftwf_plan pa, pb, px;
     int num_threads = 1;
 
 
@@ -424,40 +446,40 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
     #endif
 
     /* allocate memory for all threads here */
-    template_ext = (double**) malloc(num_threads * sizeof(double*));
+    template_ext = (float**) malloc(num_threads * sizeof(float*));
     if (template_ext == NULL) {
         printf("Error allocating template_ext\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
-    image_ext = (double**) malloc(num_threads * sizeof(double*));
+    image_ext = (float**) malloc(num_threads * sizeof(float*));
     if (image_ext == NULL) {
         printf("Error allocating image_ext\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
-    ccc = (double**) malloc(num_threads * sizeof(double*));
+    ccc = (float**) malloc(num_threads * sizeof(float*));
     if (ccc == NULL) {
         printf("Error allocating ccc\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
-    outa = (fftw_complex**) malloc(num_threads * sizeof(fftw_complex*));
+    outa = (fftwf_complex**) malloc(num_threads * sizeof(fftwf_complex*));
     if (outa == NULL) {
         printf("Error allocating outa\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
-    outb = (fftw_complex**) malloc(num_threads * sizeof(fftw_complex*));
+    outb = (fftwf_complex**) malloc(num_threads * sizeof(fftwf_complex*));
     if (outb == NULL) {
         printf("Error allocating outb\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
-    out = (fftw_complex**) malloc(num_threads * sizeof(fftw_complex*));
+    out = (fftwf_complex**) malloc(num_threads * sizeof(fftwf_complex*));
     if (out == NULL) {
         printf("Error allocating out\n");
-        free_fftw_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
+        free_fftwf_arrays(0, template_ext, image_ext, ccc, outa, outb, out);
         return -1;
     }
 
@@ -472,50 +494,50 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
         out[i] = NULL;
 
         /* allocate template_ext arrays */
-        template_ext[i] = fftw_alloc_real((size_t) fft_len * n_templates);
+        template_ext[i] = fftwf_alloc_real((size_t) fft_len * n_templates);
         if (template_ext[i] == NULL) {
             printf("Error allocating template_ext[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
 
         /* allocate image_ext arrays */
-        image_ext[i] = fftw_alloc_real(fft_len);
+        image_ext[i] = fftwf_alloc_real(fft_len);
         if (image_ext[i] == NULL) {
             printf("Error allocating image_ext[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
 
         /* allocate ccc arrays */
-        ccc[i] = fftw_alloc_real((size_t) fft_len * n_templates);
+        ccc[i] = fftwf_alloc_real((size_t) fft_len * n_templates);
         if (ccc[i] == NULL) {
             printf("Error allocating ccc[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
 
         /* allocate outa arrays */
-        outa[i] = fftw_alloc_complex((size_t) N2 * n_templates);
+        outa[i] = fftwf_alloc_complex((size_t) N2 * n_templates);
         if (outa[i] == NULL) {
             printf("Error allocating outa[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
 
         /* allocate outb arrays */
-        outb[i] = fftw_alloc_complex((size_t) N2);
+        outb[i] = fftwf_alloc_complex((size_t) N2);
         if (outb[i] == NULL) {
             printf("Error allocating outb[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
 
         /* allocate out arrays */
-        out[i] = fftw_alloc_complex((size_t) N2 * n_templates);
+        out[i] = fftwf_alloc_complex((size_t) N2 * n_templates);
         if (out[i] == NULL) {
             printf("Error allocating out[%d]\n", i);
-            free_fftw_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
+            free_fftwf_arrays(i + 1, template_ext, image_ext, ccc, outa, outb, out);
             return -1;
         }
     }
@@ -523,9 +545,9 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
     //TODO: touch all arrays - NUMA first touch???
 
     // We create the plans here since they are not thread safe.
-    pa = fftw_plan_dft_r2c_2d(n_templates, fft_len, template_ext[0], outa[0], FFTW_ESTIMATE);
-    pb = fftw_plan_dft_r2c_1d(fft_len, image_ext[0], outb[0], FFTW_ESTIMATE);
-    px = fftw_plan_dft_c2r_2d(n_templates, fft_len, out[0], ccc[0], FFTW_ESTIMATE);
+    pa = fftwf_plan_dft_r2c_2d(n_templates, fft_len, template_ext[0], outa[0], FFTW_ESTIMATE);
+    pb = fftwf_plan_dft_r2c_1d(fft_len, image_ext[0], outb[0], FFTW_ESTIMATE);
+    px = fftwf_plan_dft_c2r_2d(n_templates, fft_len, out[0], ccc[0], FFTW_ESTIMATE);
 
     /* loop over the channels */
     #pragma omp parallel for reduction(+:r) num_threads(num_threads)
@@ -538,8 +560,8 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
         #endif
 
         /* initialise memory to zero */
-        memset(template_ext[tid], 0, (size_t) fft_len * n_templates * sizeof(double));
-        memset(image_ext[tid], 0, (size_t) fft_len * sizeof(double));
+        memset(template_ext[tid], 0, (size_t) fft_len * n_templates * sizeof(float));
+        memset(image_ext[tid], 0, (size_t) fft_len * sizeof(float));
 
         /* call the routine */
         r += normxcorr_fftw_main(&templates[(size_t) n_templates * template_len * i], template_len,
@@ -550,11 +572,11 @@ int multi_normxcorr_fftw(float *templates, int n_templates, int template_len, in
     }
 
     /* free fftw memory */
-    free_fftw_arrays(num_threads, template_ext, image_ext, ccc, outa, outb, out);
-    fftw_destroy_plan(pa);
-    fftw_destroy_plan(pb);
-    fftw_destroy_plan(px);
-    fftw_cleanup();
+    free_fftwf_arrays(num_threads, template_ext, image_ext, ccc, outa, outb, out);
+    fftwf_destroy_plan(pa);
+    fftwf_destroy_plan(pb);
+    fftwf_destroy_plan(px);
+    fftwf_cleanup();
 
     return r;
 }

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -145,6 +145,7 @@ def array_ccs(array_template, array_stream, pads):
 
     for name in list(corr.XCORR_FUNCS_ORIGINAL.keys()):
         func = corr.get_array_xcorr(name)
+        print("Running %s" % name)
         cc, _ = time_func(func, name, array_template, array_stream, pads)
         out[name] = cc
     return out

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -352,7 +352,7 @@ class TestNCEDCCases(unittest.TestCase):
         for detection in individual_detections:
             individual_dict.append({'template_name': detection.template_name,
                                     'time': detection.detect_time,
-                                    'cccsum': detection.detect_val})
+                                    'cccsum': detection.detect_val.round(6)})
         detections = match_filter(template_names=self.template_names,
                                   template_list=self.templates, st=self.st,
                                   threshold=8.0, threshold_type='MAD',
@@ -362,7 +362,7 @@ class TestNCEDCCases(unittest.TestCase):
         for detection in detections:
             detection_dict = {'template_name': detection.template_name,
                               'time': detection.detect_time,
-                              'cccsum': detection.detect_val}
+                              'cccsum': detection.detect_val.round(6)}
             self.assertTrue(detection_dict in individual_dict)
 
     def test_read_write_detections(self):

--- a/eqcorrscan/utils/libnames.py
+++ b/eqcorrscan/utils/libnames.py
@@ -1,5 +1,5 @@
 """
-Helpers to get library names. Editted for our use from obspy.core.util.libnames
+Helpers to get library names. Edited for our use from obspy.core.util.libnames
 
 :copyright:
     EQcorrscan developers.
@@ -41,21 +41,22 @@ def _get_lib_name(lib):
 
 def _load_cdll(name):
     """
-    Helper function to load a shared library built during ObsPy installation
+    Helper function to load a shared library built during installation
     with ctypes.
 
     :type name: str
     :param name: Name of the library to load (e.g. 'mseed').
     :rtype: :class:`ctypes.CDLL`
     """
-    from pkg_resources import get_build_platform
     # our custom defined part of the extension file name
     libname = _get_lib_name(name)
     libdir = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'lib')
     libpath = os.path.join(libdir, libname)
     static_fftw = os.path.join(libdir, 'libfftw3-3.dll')
+    static_fftwf = os.path.join(libdir, 'libfftw3f-3.dll')
     try:
         fftw_lib = ctypes.CDLL(str(static_fftw))
+        fftw_lib = ctypes.CDLL(str(static_fftwf))
     except:
         pass
     try:

--- a/eqcorrscan/utils/libnames.py
+++ b/eqcorrscan/utils/libnames.py
@@ -55,8 +55,8 @@ def _load_cdll(name):
     static_fftw = os.path.join(libdir, 'libfftw3-3.dll')
     static_fftwf = os.path.join(libdir, 'libfftw3f-3.dll')
     try:
-        fftw_lib = ctypes.CDLL(str(static_fftw))
-        fftw_lib = ctypes.CDLL(str(static_fftwf))
+        fftw_lib = ctypes.CDLL(str(static_fftw))  # noqa: F841
+        fftwf_lib = ctypes.CDLL(str(static_fftwf))  # noqa: F841
     except:
         pass
     try:

--- a/setup.py
+++ b/setup.py
@@ -104,9 +104,9 @@ def get_libraries():
     from pkg_resources import get_build_platform
 
     if get_build_platform() in ('win32', 'win-amd64'):
-        libraries = ['libfftw3-3']
+        libraries = ['libfftw3-3', 'libfftw3f-3']
     else:
-        libraries = ['fftw3', 'fftw3_threads']
+        libraries = ['fftw3', 'fftw3_threads', 'fftw3f']
 
     return libraries
 

--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,7 @@ def get_libraries():
     if get_build_platform() in ('win32', 'win-amd64'):
         libraries = ['libfftw3-3', 'libfftw3f-3']
     else:
-        libraries = ['fftw3', 'fftw3_threads', 'fftw3f']
+        libraries = ['fftw3', 'fftw3_threads', 'fftw3f', 'fftw3f_threads']
 
     return libraries
 


### PR DESCRIPTION
Closes #163 

This branch changes from using double precision for extended templates and images (and cross-correlations) to using single-precision floats. It also changes to using the fftwf functions and fftwf_complex numbers.

Tests pass locally on my OSX machine - need to compare memory usage...