### PR TITLE
Fix memory leak in time-domain

### DIFF
--- a/eqcorrscan/lib/time_corr.c
+++ b/eqcorrscan/lib/time_corr.c
@@ -67,6 +67,7 @@ int normxcorr_time_threaded(float *template, int template_len, float *image, int
 		denom = sqrt(auto_a * auto_b);
 		ccc[k] = (float) (numerator / denom);
 	}
+	free(mean);
 	return 0;
 }
 
@@ -100,6 +101,7 @@ int normxcorr_time(float *template, int template_len, float *image, int image_le
 		denom = sqrt(auto_a * auto_b);
 		ccc[k] = (float) (numerator / denom);
 	}
+	free(mean);
 	return 0;
 }
 


### PR DESCRIPTION
Memory for the running mean is allocated in the C function for time-domain corr-correlation, but never free-ed, resulting in an annoying memory leak. This PR adds free-ing to both serial and parallel functions.