### PR TITLE
Add check for Odroid C2 board

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,12 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
+      brew update;
       brew install gcc6;
       export CC=gcc-6;
       export CXX=g++-6;
       brew install fftw;
+      brew list;
     else
       export OS="Linux";
       export py=$PYTHON_VERSION;

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,8 @@ def get_extensions():
     if get_build_platform() not in ('win32', 'win-amd64'):
         extra_link_args = ['-lm', '-lgomp']
         extra_compile_args = ['-fopenmp']
-        if 'arm' not in get_build_platform():
+        if all(arch not in get_build_platform() 
+               for arch in ['arm', 'aarch']):
             extra_compile_args.extend(['-msse2', '-ftree-vectorize'])
     else:
         extra_link_args = []

--- a/setup.py
+++ b/setup.py
@@ -141,7 +141,7 @@ def get_extensions():
     if get_build_platform() not in ('win32', 'win-amd64'):
         extra_link_args = ['-lm', '-lgomp']
         extra_compile_args = ['-fopenmp']
-        if all(arch not in get_build_platform() 
+        if all(arch not in get_build_platform()
                for arch in ['arm', 'aarch']):
             extra_compile_args.extend(['-msse2', '-ftree-vectorize'])
     else:


### PR DESCRIPTION
This PR adds a check for 64-bit ARM architecture.  Previously only 32-bit ARM arch was covered.

Adding this allows compilation of C routines on 64-Bit ARM chips (such as Odroid C2), all it does is omit the `-msse2` compile flag for ARM architectures.