### PR TITLE
Add convenience imports

### DIFF
--- a/eqcorrscan/__init__.py
+++ b/eqcorrscan/__init__.py
@@ -11,6 +11,14 @@ import importlib
 import sys
 import warnings
 
+from eqcorrscan.core.match_filter import (  # NOQA
+    match_filter, Detection, Party, Tribe, Family, Template)
+from eqcorrscan.core.subspace import Detector, read_detector  # NOQA
+from eqcorrscan.core.lag_calc import lag_calc  # NOQA
+
+from eqcorrscan.utils.correlate import (  # NOQA
+    get_stream_xcorr, get_array_xcorr)
+
 __all__ = ['core', 'utils', 'tutorials']
 
 __version__ = '0.2.7'

--- a/eqcorrscan/__init__.py
+++ b/eqcorrscan/__init__.py
@@ -17,7 +17,7 @@ from eqcorrscan.core.subspace import Detector, read_detector  # NOQA
 from eqcorrscan.core.lag_calc import lag_calc  # NOQA
 
 from eqcorrscan.utils.correlate import (  # NOQA
-    get_stream_xcorr, get_array_xcorr)
+    get_stream_xcorr, get_array_xcorr, register_array_xcorr)
 
 __all__ = ['core', 'utils', 'tutorials']
 


### PR DESCRIPTION
This PR adds a few more commonly used convenience imports to the top of the eqcorrscan namespace.

It adds:
- eqcorrscan.core.match_filter
  - match_filter, Detection, Party, Tribe, Family, Template
- eqcorrscan.core.subspace
  - Detector, read_detector
- eqcorrscan.core.lag_calc
  - lag_calc
- eqcorrscan.utils.correlate
  - get_stream_xcorr, get_array_xcorr

This PR closes #155 

I will leave this open for a couple of days - if anyone wants anything else in here let me know and I can add it.