### PR TITLE
Patch low amplitudes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Current
 * Minima not correctly identified in find_peaks in previous versions - bug fixed
 * Compiled peak-finding routine written to speed-up peak-finding.
+* BUG-FIX: changed minimum variance for fftw correlation backend.
 
 ## 0.2.7
 * Patch multi_corr.c to work with more versions of MSVC;

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ We have a manuscript in review, if you make use of EQcorrscan please cite the fo
 
 Chamberlain, C. J., Hopp, C. J., Boese, C. M., Warren-Smith, E., Chambers, D., Chu, S. X., Michailos, K., Townend, J., EQcorrscan: Repeating and near-repeating earthquake detection and analysis in Python. Seismological Research Letters *in review*
 
-If you want to you should also cite the version number: [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.891131.svg)](https://doi.org/10.5281/zenodo.891131)
+If you want to you should also cite the version number:
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.893621.svg)](https://doi.org/10.5281/zenodo.893621)
+
 
 # Test status
 Note that tests for travis and appveyor are run daily on master as cron jobs, and may reflect time-out issues.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Note that tests for travis and appveyor are run daily on master as cron jobs, an
 | Chat on gitter | [![Join the chat at https://gitter.im/eqcorrscan/EQcorrscan](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/eqcorrscan/EQcorrscan?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 # Installation
+
+The easiest way to install EQcorrscan is through anaconda:
+[![Anaconda-Server Badge](https://anaconda.org/conda-forge/eqcorrscan/badges/installer/conda.svg)](https://conda.anaconda.org/conda-forge)
+
 Installation has been tested on both OSX and Linux (Ubuntu), and
 Windows systems.  We support Python versions 2.7, 3.4, 3.5 and 3.6.
 Note that, although we support Windows, EQcorrscan is optimized for

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -3098,7 +3098,7 @@ def _group_detect(templates, stream, threshold, threshold_type, trig_int,
     :param overlap:
         Either None, "calculate" or a float of number of seconds to
         overlap detection streams by.  This is to counter the effects of
-        the delay-and-stack in calcualting cross-correlation sums. Setting
+        the delay-and-stack in calculating cross-correlation sums. Setting
         overlap = "calculate" will work out the appropriate overlap based
         on the maximum lags within templates.
     :type debug: int
@@ -3131,8 +3131,7 @@ def _group_detect(templates, stream, threshold, threshold_type, trig_int,
             cores=cores, stream=stream, daylong=daylong,
             ignore_length=ignore_length, overlap=overlap)
     else:
-        warnings.warn('Not performing any processing on the '
-                      'continuous data.')
+        warnings.warn('Not performing any processing on the continuous data.')
         st = [stream]
     detections = []
     party = Party()
@@ -3234,8 +3233,9 @@ def _group_process(template_group, parallel, debug, cores, stream, daylong,
         func = shortproc
         starttime = stream.sort(['starttime'])[0].stats.starttime
     endtime = stream.sort(['endtime'])[-1].stats.endtime
-    n_chunks = int((endtime - starttime + 1) / (master.process_length -
-                                                overlap))
+    data_len_samps = round((endtime - starttime) * master.samp_rate) + 1
+    chunk_len_samps = (master.process_length - overlap) * master.samp_rate
+    n_chunks = int(data_len_samps / chunk_len_samps)
     if n_chunks == 0:
         print('Data must be process_length or longer, not computing')
     for i in range(n_chunks):

--- a/eqcorrscan/doc/intro.rst
+++ b/eqcorrscan/doc/intro.rst
@@ -30,7 +30,7 @@ get involved the best place to start, and the most valuable thing for your
 understanding, and for the health of this package would be to contribute tests and
 documentation.
 
-Installation - Updated for version 0.2.x
+Installation - Updated for version 0.2.7
 ----------------------------------------
 
 In general we recommend users to install EQcorrscan in a virtual environment,
@@ -41,9 +41,17 @@ environment with the following:
 
     conda create -n eqcorrscan colorama numpy scipy matplotlib obspy bottleneck pyproj
     source activate eqcorrscan
+    
+To then install EQcorrscan you can simply run:
 
-Non-Python dependancies: Ubuntu:
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. code-block:: bash
+
+    conda install -c conda-forge eqcorrscan
+
+And you are done! Otherwise, if you want to install via pip then the following applies:
+
+Non-Python dependancies (without conda): Ubuntu:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Prior to installing the python routines you will need to install the fftw
 library.  On linux use apt (or your default package manager - note you may need
@@ -85,8 +93,8 @@ used), as such, by default, the correlation routines are compiled as serial
 workflows on windows.  If you have a need for this threading in windows please
 get in touch with the developers.
 
-Final EQcorrscan install:
-~~~~~~~~~~~~~~~~~~~~~~~~~
+EQcorrscan install via pip:
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once you have installed fftw the EQcorrscan install should be as simple as:
 

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -128,7 +128,7 @@ def pads(array_template):
 
 @pytest.fixture(scope='module')
 def array_ccs(array_template, array_stream, pads):
-    """  use each function stored in the normcorr cache to correlate the
+    """ Use each function stored in the normxcorr cache to correlate the
      templates and arrays, return a dict with keys as func names and values
      as the cc calculated by said function"""
     out = {}
@@ -140,7 +140,21 @@ def array_ccs(array_template, array_stream, pads):
         out[name] = cc
     return out
 
+@pytest.fixture(scope='module')
+def array_ccs_low_amp(array_template, array_stream, pads):
+    """ Use each function stored in the normxcorr cache to correlate the
+     templates and arrays, return a dict with keys as func names and values
+     as the cc calculated by said function.
+     This specifically tests low amplitude streams as raised in issue #181."""
+    out = {}
 
+    for name in list(corr.XCORR_FUNCS_ORIGINAL.keys()):
+        func = corr.get_array_xcorr(name)
+        print("Running %s" % name)
+        cc, _ = time_func(
+            func, name, array_template, array_stream * 10e-8, pads)
+        out[name] = cc
+    return out
 # stream fixtures
 
 
@@ -202,6 +216,12 @@ class TestArrayCorrelateFunctions:
         expected, defined by starting_index variable """
         for name, cc in array_ccs.items():
             assert np.isclose(cc[0, starting_index], 1., atol=self.atol)
+
+    def test_non_zero_median(self, array_ccs_low_amp):
+        """ Ensure that the median of correlations returned is non-zero,
+        this happens with v.0.2.7 when the amplitudes are low."""
+        for name, cc in array_ccs_low_amp.items():
+            assert np.median(cc) != 0.0
 
 
 @pytest.mark.serial

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -28,6 +28,7 @@ import contextlib
 import copy
 import ctypes
 import os
+import warnings
 from multiprocessing import Pool as ProcessPool, cpu_count
 from multiprocessing.pool import ThreadPool
 
@@ -499,9 +500,13 @@ def fftw_normxcorr(templates, stream, pads, threaded=False, *args, **kwargs):
         np.ascontiguousarray(stream, np.float32), stream_length,
         np.ascontiguousarray(ccc, np.float32), fftshape,
         used_chans_np, pads_np)
-    if ret != 0:
+    if ret not in [0, 999]:
         print(ret)
         raise MemoryError()
+    elif ret == 999:
+        msg = ("Some correlations not computed, are there "
+               "zeros in data? If not, consider increasing gain.")
+        warnings.warn(msg)
 
     return ccc, used_chans
 


### PR DESCRIPTION
Fixes #181.

This PR changes the `acceptedDiff` value in the fftw correlation backend to a smaller value (the smallest acceptable without incorrectly converting correlations to float) to allow data with lower variance to be used.

It also introduces a warning to explicitly show the user if the variance is below this level.

A test is also added with low amplitudes that previously failed and now does not.