### PR TITLE
Change decimation strategy

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Current
 * Minima not correctly identified in find_peaks in previous versions - bug fixed
 * Compiled peak-finding routine written to speed-up peak-finding.
+* Change default match-filter plotting to not decimate unless it has to.
 
 ## 0.2.7
 * Patch multi_corr.c to work with more versions of MSVC;

--- a/conftest.py
+++ b/conftest.py
@@ -57,8 +57,9 @@ def clean_up_test_files():
         if os.path.isfile(fi):
             try:
                 os.remove(fi)
-            except FileNotFoundError:
+            except Exception as e:
                 print("File not found, assuming already cleaned")
+                print(e)
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/conftest.py
+++ b/conftest.py
@@ -55,7 +55,10 @@ def clean_up_test_files():
     # remove files
     for fi in files_to_kill:
         if os.path.isfile(fi):
-            os.remove(fi)
+            try:
+                os.remove(fi)
+            except FileNotFoundError:
+                print("File not found, assuming already cleaned")
 
 
 @pytest.fixture(scope='session', autouse=True)
@@ -76,7 +79,11 @@ def clean_up_test_directories():
     # remove files
     for directory in directories_to_kill:
         if os.path.isdir(directory):
-            shutil.rmtree(directory)
+            try:
+                shutil.rmtree(directory)
+            except Exception as e:
+                print("Could not find directory, already cleaned?")
+                print(e)
 
 
 # ------------- add objects to global pytest scope

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -2312,10 +2312,7 @@ def _match_filter_plot(stream, cccsum, template_names, rawthresh, plotdir,
     plt.ioff()
     stream_plot = copy.deepcopy(stream[0])
     # Downsample for plotting
-    stream_len = stream[0].stats.npts
-    while stream_len > 10e5:
-        stream_plot.decimate(4)
-        stream_len = stream[0].stats.npts
+    stream_plot = _plotting_decimation(stream_plot, 10e5, 4)
     cccsum_plot = Trace(cccsum)
     cccsum_plot.stats.sampling_rate = stream[0].stats.sampling_rate
     # Resample here to maintain shape better
@@ -2333,6 +2330,35 @@ def _match_filter_plot(stream, cccsum, template_names, rawthresh, plotdir,
     triple_plot(cccsum=cccsum_plot, cccsum_hist=cccsum_hist,
                 trace=stream_plot, threshold=rawthresh, save=True,
                 savefile=plot_name)
+
+
+def _plotting_decimation(trace, max_len=10e5, decimation_step=4):
+    """
+    Decimate data until required length reached.
+
+    :type trace: obspy.core.stream.Trace
+    :param trace: Trace to decimate
+    type max_len: int
+    :param max_len: Maximum length in samples
+    :type decimation_step: int
+    :param decimation_step: Decimation factor to use for each step.
+
+    :return: obspy.core.stream.Trace
+
+    .. rubric: Example
+
+    >>> from obspy import Trace
+    >>> import numpy as np
+    >>> trace = Trace(np.random.randn(1000))
+    >>> trace = _plotting_decimation(trace, max_len=100, decimation_step=2)
+    >>> print(trace.stats.npts)
+    63
+    """
+    trace_len = trace.stats.npts
+    while trace_len > max_len:
+        trace.decimate(decimation_step)
+        trace_len = trace.stats.npts
+    return trace
 
 
 if __name__ == "__main__":

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -2312,7 +2312,10 @@ def _match_filter_plot(stream, cccsum, template_names, rawthresh, plotdir,
     plt.ioff()
     stream_plot = copy.deepcopy(stream[0])
     # Downsample for plotting
-    stream_plot.decimate(int(stream[0].stats.sampling_rate / 10))
+    stream_len = stream[0].stats.npts
+    while stream_len > 10e5:
+        stream_plot.decimate(4)
+        stream_len = stream[0].stats.npts
     cccsum_plot = Trace(cccsum)
     cccsum_plot.stats.sampling_rate = stream[0].stats.sampling_rate
     # Resample here to maintain shape better


### PR DESCRIPTION
This PR fixes #179 

This sets a maximum allowable length in points for the match-filter internal plotting, and runs a while loop to decimate until this is reached.

There is no test for this because plotting is not yet tested.