### PR TITLE
Do not do unnecesary processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,10 @@
 * Minima not correctly identified in find_peaks in previous versions - bug fixed
 * Compiled peak-finding routine written to speed-up peak-finding.
 * BUG-FIX: changed minimum variance for fftw correlation backend.
+* Do not try to process when no processing needs to be done in 
+  core.match_filter._group_process.
+* Length checking in core.match_filter._group_process done in samples rather
+  than time.
 
 ## 0.2.7
 * Patch multi_corr.c to work with more versions of MSVC;

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2311,7 +2311,7 @@ class Tribe(object):
         :param overlap:
             Either None, "calculate" or a float of number of seconds to
             overlap detection streams by.  This is to counter the effects of
-            the delay-and-stack in calcualting cross-correlation sums. Setting
+            the delay-and-stack in calculating cross-correlation sums. Setting
             overlap = "calculate" will work out the appropriate overlap based
             on the maximum lags within templates.
         :type debug: int
@@ -3212,6 +3212,12 @@ def _group_process(template_group, parallel, debug, cores, stream, daylong,
         'highcut': master.highcut, 'lowcut': master.lowcut,
         'samp_rate': master.samp_rate, 'debug': debug,
         'parallel': parallel, 'num_cores': cores}
+    # Check whether any processing actually needs to be done.
+    if kwargs['highcut'] is None and kwargs['lowcut'] is None:
+        st_samp_rates = set([tr.stats.sampling_rate for tr in stream])
+        if len(st_samp_rates) == 1 and \
+           st_samp_rates.pop() == kwargs['samp_rate']:
+            return [stream]
     if daylong:
         if not master.process_length == 86400:
             warnings.warn(

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -615,6 +615,33 @@ class TestMatchObjects(unittest.TestCase):
                             det.__dict__[key], check_det.__dict__[key])
             # self.assertEqual(fam.template, check_fam.template)
 
+    def test_tribe_detect_no_processing(self):
+        """Test that no processing is done when it isn't necessary."""
+        tribe = self.tribe.copy()
+        for template in tribe:
+            template.lowcut = None
+            template.highcut = None
+        party = tribe.detect(
+            stream=self.st, threshold=8.0, threshold_type='MAD',
+            trig_int=6.0, daylong=False, plotvar=False, parallel_process=False)
+        self.assertEqual(len(party), 4)
+        for fam, check_fam in zip(party, self.party):
+            for det, check_det in zip(fam.detections, check_fam.detections):
+                for key in det.__dict__.keys():
+                    if key == 'event':
+                        continue
+                    if isinstance(det.__dict__[key], float):
+                        if not np.allclose(det.__dict__[key],
+                                           check_det.__dict__[key], atol=0.1):
+                            print(key)
+                        self.assertTrue(np.allclose(
+                            det.__dict__[key], check_det.__dict__[key],
+                            atol=0.2))
+                    else:
+                        self.assertEqual(
+                            det.__dict__[key], check_det.__dict__[key])
+            # self.assertEqual(fam.template, check_fam.template)
+
     @pytest.mark.flaky(reruns=2)
     def test_client_detect(self):
         """Test the client_detect method."""


### PR DESCRIPTION
This PR changes `eqcorrscan.core.match_filter._group_process` to check whether any processing actually needs to be done, and if not, then it will return the stream input.