### PR TITLE
In core.match_filter.party.rethreshold, do not use list.remove

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -440,6 +440,7 @@ class Party(object):
         4
         """
         for family in self.families:
+            rethresh_detections = []
             for d in family.detections:
                 if new_threshold_type == 'MAD' and d.threshold_type == 'MAD':
                     new_thresh = (d.threshold /
@@ -456,8 +457,9 @@ class Party(object):
                     raise MatchFilterError(
                         'new_threshold_type %s is not recognised' %
                         str(new_threshold_type))
-                if d.detect_val < new_thresh:
-                    family.detections.remove(d)
+                if d.detect_val >= new_thresh:
+                    rethresh_detections.append(d)
+            family.detections = rethresh_detections
             family.catalog = Catalog([d.event for d in family])
         return self
 

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -458,6 +458,9 @@ class Party(object):
                         'new_threshold_type %s is not recognised' %
                         str(new_threshold_type))
                 if d.detect_val >= new_thresh:
+                    d.threshold = new_thresh
+                    d.threshold_input = new_threshold
+                    d.threshold_type = new_threshold_type
                     rethresh_detections.append(d)
             family.detections = rethresh_detections
             family.catalog = Catalog([d.event for d in family])

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -763,6 +763,23 @@ class TestMatchObjects(unittest.TestCase):
         catalog = self.party.lag_calc(stream=self.st, pre_processed=True)
         self.assertEqual(len(catalog), 3)
 
+    def test_party_rethreshold(self):
+        """Make sure that rethresholding removes the events we want it to."""
+        party = self.party.copy()
+        # Append a load of detections to the first family
+        for i in range(200):
+            det = party[0][0].copy()
+            det.detect_time += i * 20
+            det.detect_val = det.threshold + (i * 1e-1)
+            det.id = str(i)
+            party[0].detections.append(det)
+        self.assertEqual(len(party), 204)
+        party.rethreshold(new_threshold=9)
+        for family in party:
+            for d in family:
+                self.assertEqual(d.threshold_input, 9.0)
+                self.assertGreaterEqual(d.detect_val, d.threshold)
+
     def test_day_long_methods(self):
         """Conduct a test using day-long data."""
         client = Client('NCEDC')


### PR DESCRIPTION
This fixes a bug where detections below the threshold were not correctly removed in the `rethreshold` method. Looks like the `remove` method on lists in Python is unreliable, or doesn't do what I expect it to do.

This PR needs a test.