### PR TITLE
Warn when variance is low, and add docs

### DIFF
--- a/eqcorrscan/doc/submodules/core.match_filter.Template.rst
+++ b/eqcorrscan/doc/submodules/core.match_filter.Template.rst
@@ -1,6 +1,10 @@
 match_filter.Template
 =====================
 
+See notes and warnings on correlations here: correlation_warnings_
+
+.. _correlation_warnings: utils.correlate.html#notes-on-accuracy
+
 .. currentmodule:: eqcorrscan.core.match_filter
 
 .. autoclass:: Template

--- a/eqcorrscan/doc/submodules/core.match_filter.Tribe.rst
+++ b/eqcorrscan/doc/submodules/core.match_filter.Tribe.rst
@@ -1,6 +1,10 @@
 match_filter.Tribe
 ==================
 
+See notes and warnings on correlations here: correlation_warnings_
+
+.. _correlation_warnings: utils.correlate.html#notes-on-accuracy
+
 .. currentmodule:: eqcorrscan.core.match_filter
 
 .. autoclass:: Tribe

--- a/eqcorrscan/doc/submodules/core.match_filter.rst
+++ b/eqcorrscan/doc/submodules/core.match_filter.rst
@@ -1,6 +1,10 @@
 match_filter
 ------------
 
+See notes and warnings on correlations here: correlation_warnings_
+
+.. _correlation_warnings: utils.correlate.html#notes-on-accuracy
+
 .. currentmodule:: eqcorrscan.core.match_filter
 .. automodule:: eqcorrscan.core.match_filter
 

--- a/eqcorrscan/doc/submodules/utils.correlate.rst
+++ b/eqcorrscan/doc/submodules/utils.correlate.rst
@@ -139,3 +139,20 @@ or within the scope of a context manager:
     ...                           1, False) # doctest:+ELLIPSIS
     calling custom xcorr function...
     >>> set_xcorr.revert()  # change it back to the previous state
+
+
+Notes on accuracy
+~~~~~~~~~~~~~~~~~
+To cope with floating-point rounding errors, correlations may not be
+calculated for data with low variance.  If you see a warning saying:
+*"Some correlations not computed, are there zeros in the data? If not
+consider increasing gain"*, check whether your data have zeros, and if not,
+but have low, but real amplitudes, multiply your data by some value.
+
+Warning
+~~~~~~~
+If data are padded with zeros prior to filtering then correlations may be
+incorrectly calculated where there are zeros. You should always pad after
+filtering.  If you see warnings saying *"Low variance, possible zeros, check
+result"*, you should check that you have padded correctly and check that
+correlations haven't been calculated when you don't expect them.

--- a/eqcorrscan/doc/submodules/utils.pre_processing.rst
+++ b/eqcorrscan/doc/submodules/utils.pre_processing.rst
@@ -1,6 +1,11 @@
 pre_processing
 --------------
 
+Pre-processing modules take care of ensuring all data are processed the same. Note that gaps should
+be padded after filtering if you decide not to use these routines (see notes in correlation_warnings_).
+
+.. _correlation_warnings: utils.correlate.html#notes-on-accuracy
+
 .. currentmodule:: eqcorrscan.utils.pre_processing
 .. automodule:: eqcorrscan.utils.pre_processing
 

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -8,7 +8,7 @@ both in terms of overall speed, and in memory usage.  The time-domain is the
 most memory efficient but slowest routine (although fast for small cases of
 less than a few hundred correlations), the Numpy routine is fast, but memory
 inefficient due to a need to store large double-precision arrays for
-normalisation.  The fftw compiled routine is fastest and more memory efficient
+normalisation.  The fftw compiled routine is faster and more memory efficient
 than the Numpy routine.
 
 :copyright:

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -39,6 +39,8 @@
 #endif
 // Define minimum variance to compute correlations - requires some signal
 #define ACCEPTED_DIFF 1e-15
+// Define difference to warn user on
+#define WARN_DIFF 1e-10
 
 // Prototypes
 int normxcorr_fftw(float*, long, long, float*, long, float*, long, int*, int*);
@@ -144,6 +146,9 @@ int normxcorr_fftw_threaded(float *templates, long template_len, long n_template
             float c = ((ccc[(t * fft_len) + startind] / (fft_len * n_templates)) - norm_sums[t] * mean) / stdev;
             status += set_ncc(t, 0, template_len, image_len, (float) c, used_chans, pad_array, ncc);
         }
+        if (var <= WARN_DIFF){
+            printf("Low variance, possible zeros, check result. Index: 0 Variance: %g\n", var);
+        }
     }
     // Center and divide by length to generate scaled convolution
     for(i = 1; i < (image_len - template_len + 1); ++i){
@@ -159,6 +164,9 @@ int normxcorr_fftw_threaded(float *templates, long template_len, long n_template
             for (t = 0; t < n_templates; ++t){
                 float c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
                 status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
+            }
+            if (var <= WARN_DIFF){
+                printf("Low variance, possible zeros, check result. Index: %li Variance: %g\n", i, var);
             }
         }
     }
@@ -360,6 +368,9 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
             c /= stdev;
             status += set_ncc(t, 0, template_len, image_len, (float) c, used_chans, pad_array, ncc);
         }
+        if (var[0] <= WARN_DIFF){
+            printf("Low variance, possible zeros, check result. Index: 0 Variance: %g\n", var[0]);
+        }
     } else {
         unused_corr = 1;
     }
@@ -383,6 +394,9 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
                 double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i] );
                 c /= stdev;
                 status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
+            }
+            if (var[i] <= WARN_DIFF){
+                printf("Low variance, possible zeros, check result. Index: %li Variance: %g\n", i, var[i]);
             }
         } else {
             unused_corr = 1;


### PR DESCRIPTION
This PR implements option 2 from #203.  Users are warned when the variance of the data is worryingly low (not non-zero) because this might be due to gaps padded after filtering. This copes with a change in behaviour from 0.2.7.