### PR TITLE
Add cores argument to find_peaks

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -4135,7 +4135,7 @@ def match_filter(template_names, template_list, st, threshold,
     all_peaks = multi_find_peaks(
         arr=cccsums, thresh=thresholds, debug=debug, parallel=parallel,
         trig_int=int(trig_int * stream[0].stats.sampling_rate),
-        full_peaks=full_peaks)
+        full_peaks=full_peaks, cores=cores)
     for i, cccsum in enumerate(cccsums):
         if np.abs(np.mean(cccsum)) > 0.05:
             warnings.warn('Mean is not zero!  Check this!')

--- a/eqcorrscan/utils/findpeaks.py
+++ b/eqcorrscan/utils/findpeaks.py
@@ -168,7 +168,8 @@ def find_peaks2_short(arr, thresh, trig_int, debug=0, starttime=False,
 
 
 def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
-                     samp_rate=1.0, parallel=True, full_peaks=False):
+                     samp_rate=1.0, parallel=True, full_peaks=False,
+                     cores=None):
     """
     Wrapper for find-peaks for multiple arrays.
 
@@ -179,8 +180,9 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
         The threshold below which will be considered noise and peaks will not
         be found in. One threshold per array.
     :type trig_int: int
-    :param trig_int: The minimum difference in samples between triggers,\
-        if multiple peaks within this window this code will find the highest.
+    :param trig_int: 
+        The minimum difference in samples between triggers, if multiple
+        peaks within this window this code will find the highest.
     :type debug: int
     :param debug: Optional, debug level 0-5
     :type starttime: obspy.core.utcdatetime.UTCDateTime
@@ -192,6 +194,9 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
         Whether to compute in parallel or not - will use multiprocessing
     :type full_peaks: bool
     :param full_peaks: See `eqcorrscan.utils.findpeaks.find_peaks2_short`
+    :type cores: int
+    :param cores: 
+        Maximum number of processes to spin up for parallel peak-finding
 
     :returns:
         List of list of tuples of (peak, index) in same order as input arrays
@@ -204,7 +209,9 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
                 starttime=starttime, samp_rate=samp_rate,
                 full_peaks=full_peaks))
     else:
-        with pool_boy(Pool=Pool, traces=arr.shape[0]) as pool:
+        if not cores:
+            cores = arr.shape[0]
+        with pool_boy(Pool=Pool, traces=cores) as pool:
             params = ((sub_arr, arr_thresh, trig_int, debug,
                        False, 1.0, full_peaks)
                       for sub_arr, arr_thresh in zip(arr, thresh))

--- a/eqcorrscan/utils/findpeaks.py
+++ b/eqcorrscan/utils/findpeaks.py
@@ -72,11 +72,13 @@ def find_peaks2_short(arr, thresh, trig_int, debug=0, starttime=False,
     :type arr: numpy.ndarray
     :param arr: 1-D numpy array is required
     :type thresh: float
-    :param thresh: The threshold below which will be considered noise and \
-        peaks will not be found in.
+    :param thresh:
+        The threshold below which will be considered noise and peaks will
+        not be found in.
     :type trig_int: int
-    :param trig_int: The minimum difference in samples between triggers,\
-        if multiple peaks within this window this code will find the highest.
+    :param trig_int:
+        The minimum difference in samples between triggers, if multiple
+        peaks within this window this code will find the highest.
     :type debug: int
     :param debug: Optional, debug level 0-5
     :type starttime: obspy.core.utcdatetime.UTCDateTime
@@ -180,7 +182,7 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
         The threshold below which will be considered noise and peaks will not
         be found in. One threshold per array.
     :type trig_int: int
-    :param trig_int: 
+    :param trig_int:
         The minimum difference in samples between triggers, if multiple
         peaks within this window this code will find the highest.
     :type debug: int
@@ -195,7 +197,7 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
     :type full_peaks: bool
     :param full_peaks: See `eqcorrscan.utils.findpeaks.find_peaks2_short`
     :type cores: int
-    :param cores: 
+    :param cores:
         Maximum number of processes to spin up for parallel peak-finding
 
     :returns:


### PR DESCRIPTION
Find-peaks runs into memory assignment errors when the number of processes is large (on my machine, 80). This PR implements the `cores` kwarg for multi_find_peaks.