### PR TITLE
WIP: Add logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,9 @@
 * Cleaned imports in utils modules
 * Removed parallel checking loop in archive_read.
 * Add better checks for timing in lag-calc functions (#207)
+* Convert most print statements in match-filter functions to logging calls. The user
+  can provide a logger themselves for better control of output (e.g. can log all log
+  calls to a file and only some to screen, or nothing/anything in between).
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -253,9 +253,10 @@ def _channel_loop(detection, template, min_cc, detection_id, interpolate, i,
                    % (pre_lag_ccsum, checksum))
             raise LagCalcError(msg)
     else:
-        logger.warning('Cannot check if cccsum is better, used {0} channels '
-                       'for detection, but {1} are used here'.format(
-            detect_chans, used_chans))
+        logger.warning(
+            'Cannot check if cccsum is better, used {0} channels '
+            'for detection, but {1} are used here'.format(
+                detect_chans, used_chans))
     return i, event
 
 

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -4122,7 +4122,8 @@ def match_filter(template_names, template_list, st, threshold,
                         logger.warning(
                             'Removing template channel {0}.{1}.{2}.{3} due to '
                             'no matches in continuous data'.format(
-                                stachan[0], stachan[1], stachan[2], stachan[3]))
+                                stachan[0], stachan[1], stachan[2],
+                                stachan[3]))
     template_stachan = _template_stachan
     # Remove un-needed channels from continuous data.
     for tr in stream:

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -50,7 +50,7 @@ from obspy.core.event import Catalog
 from obspy.clients.fdsn import Client as FDSNClient
 from obspy.clients.seishub import Client as SeisHubClient
 
-from eqcorrscan.utils.debug_log import debug_print
+from eqcorrscan.utils.debug_log import debug_print, debug_logger
 from eqcorrscan.utils.sac_util import sactoevent
 from eqcorrscan.utils import pre_processing
 from eqcorrscan.core import EQcorrscanDeprecationWarning
@@ -77,7 +77,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                  length, prepick, swin, process_len=86400,
                  all_horiz=False, delayed=True, plot=False, debug=0,
                  return_event=False, min_snr=None, parallel=False,
-                 **kwargs):
+                 logger=None, **kwargs):
     """
     Generate processed and cut waveforms for use as templates.
 
@@ -124,6 +124,10 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         the whole window given.
     :type parallel: bool
     :param parallel: Whether to process data in parallel or not.
+    :type logger: `logging.logger`
+    :param logger:
+        Logger for output, use your own logger to allow more advanced
+        logging output.
 
     :returns: List of :class:`obspy.core.stream.Stream` Templates
     :rtype: list
@@ -212,6 +216,9 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     >>> print(len(templates[0]))
     15
     """
+    if not logger:
+        logger = debug_logger(name="eqcorrscan.core.template_gen.template_gen",
+                              debug_level=debug)
     client_map = {'from_client': 'fdsn', 'from_seishub': 'seishub'}
     assert method in ('from_client', 'from_seishub', 'from_meta_file',
                       'from_sac')
@@ -263,7 +270,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                 catalog=sub_catalog, data_pad=data_pad,
                 process_len=process_len, available_stations=available_stations,
                 debug=debug)
-        debug_print('Pre-processing data', 0, debug)
+        logger.info('Pre-processing data')
         st.merge()
         if process:
             data_len = max([len(tr.data) / tr.stats.sampling_rate
@@ -283,12 +290,13 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                 st = pre_processing.dayproc(
                     st=st, lowcut=lowcut, highcut=highcut,
                     filt_order=filt_order, samp_rate=samp_rate, debug=debug,
-                    parallel=parallel, starttime=UTCDateTime(starttime))
+                    parallel=parallel, starttime=UTCDateTime(starttime),
+                    logger=logger)
             else:
                 st = pre_processing.shortproc(
                     st=st, lowcut=lowcut, highcut=highcut,
                     filt_order=filt_order, parallel=parallel,
-                    samp_rate=samp_rate, debug=debug)
+                    samp_rate=samp_rate, debug=debug, logger=logger)
         data_start = min([tr.stats.starttime for tr in st])
         data_end = max([tr.stats.endtime for tr in st])
 
@@ -301,22 +309,22 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             # Check that the event is within the data
             for pick in event.picks:
                 if not data_start < pick.time < data_end:
-                    debug_print("Pick outside of data span:\nPick time %s\n"
-                                "Start time %s\nEnd time: %s" %
-                                (str(pick.time), str(data_start),
-                                 str(data_end)), 0, debug)
+                    logger.warning(
+                        "Pick outside of data span:\nPick time {0}\n"
+                        "Start time {1}\nEnd time: {2}".format(
+                            pick.time, data_start, data_end))
                     use_event = False
             if not use_event:
-                warnings.warn('Event is not within data time-span')
+                logger.warning('Event is not within data time-span')
                 continue
             # Read in pick info
-            debug_print("I have found the following picks", 0, debug)
+            logger.debug("I have found the following picks:")
             for pick in event.picks:
                 if not pick.waveform_id:
-                    print('Pick not associated with waveforms, will not use.')
-                    print(pick)
+                    logger.warning('Pick not associated with waveforms, will '
+                                   'not use: {0}'.format(pick))
                     continue
-                debug_print(pick, 0, debug)
+                logger.debug(pick.__str__())
                 stations.append(pick.waveform_id.station_code)
                 channels.append(pick.waveform_id.channel_code)
             # Check to see if all picks have a corresponding waveform
@@ -327,7 +335,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             template = _template_gen(
                 event.picks, st, length, swin, prepick=prepick, plot=plot,
                 debug=debug, all_horiz=all_horiz, delayed=delayed,
-                min_snr=min_snr)
+                min_snr=min_snr, logger=logger)
             process_lengths.append(len(st[0].data) / samp_rate)
             temp_list.append(template)
         del st
@@ -479,7 +487,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
 
 def _template_gen(picks, st, length, swin='all', prepick=0.05,
                   all_horiz=False, delayed=True, plot=False, min_snr=None,
-                  debug=0):
+                  debug=0, logger=None):
     """
     Master function to generate a multiplexed template for a single event.
 
@@ -517,6 +525,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         the whole window given.
     :type debug: int
     :param debug: Debug output level from 0-5.
+    :type logger: `logging.logger`
+    :param logger:
+        Logger for output, use your own logger to allow more advanced
+        logging output.
 
     :returns: Newly cut template.
     :rtype: :class:`obspy.core.stream.Stream`
@@ -546,35 +558,38 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     .. warning:: If there is no phase_hint included in picks, and swin=all, \
         all channels with picks will be used.
     """
-    from eqcorrscan.utils.debug_log import debug_print
     from eqcorrscan.utils.plotting import pretty_template_plot as tplot
     from eqcorrscan.core.bright_lights import _rms
     picks_copy = copy.deepcopy(picks)  # Work on a copy of the picks and leave
     # the users picks intact.
+    if not logger:
+        logger = debug_logger(
+            name="eqcorrscan.core.template_gen._template_gen",
+            debug_level=debug)
     assert swin in ['P', 'all', 'S', 'P_all', 'S_all']
     for pick in picks_copy:
         if not pick.waveform_id:
-            print('Pick not associated with waveform, will not use it.')
-            print(pick)
+            logger.warning('Pick not associated with waveform, '
+                           'will not use it: \n{0}'.format(pick))
             picks_copy.remove(pick)
             continue
         if not pick.waveform_id.station_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
+            logger.warning('Pick not associated with a station, '
+                           'will not use it: \n{0}'.format(pick))
             picks_copy.remove(pick)
             continue
         if not pick.waveform_id.channel_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
+            logger.warning('Pick not associated with a channel, '
+                           'will not use it: \n{0}'.format(pick))
             picks_copy.remove(pick)
             continue
     for tr in st:
         # Check that the data can be represented by float16, and check they
         # are not all zeros
         if np.all(tr.data.astype(np.float16) == 0):
-            warnings.warn('Trace is all zeros at float16 level,'
-                          'either gain or check. Not using in template.')
-            print(tr)
+            logger.warning(
+                'Trace {0} is all zeros at float16 level, either gain or check.'
+                ' Not using in template.'.format(tr.id))
             st.remove(tr)
     if plot:
         stplot = st.copy()
@@ -638,51 +653,45 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     # Cut the data
     st1 = Stream()
     for _starttime in starttimes:
-        debug_print("Working on channel %s.%s" %
-                    (_starttime['station'], _starttime['channel']),
-                    debug_level=0, print_level=debug)
+        logger.info("Working on channel {0}.{1}".format(
+            _starttime['station'], _starttime['channel']))
         tr = st.select(
             station=_starttime['station'], channel=_starttime['channel'])[0]
-        debug_print("Found Trace %s" % tr.__str__(), debug_level=0,
-                    print_level=debug)
+        logger.debug("Found Trace {0}".format(tr.__str__()))
         noise_amp = _rms(tr.data)
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                msg = ('Pick for ' + pick.waveform_id.station_code + '.' +
-                       pick.waveform_id.channel_code + ' has no phase ' +
-                       'hint given, you should not use this template for ' +
-                       'cross-correlation re-picking!')
-                warnings.warn(msg)
+                logger.warning(
+                    'Pick for {0}.{1} has no phase hint given, you should not '
+                    'use this template for cross-correlation '
+                    're-picking!'.format(pick.waveform_id.station_code,
+                                         pick.waveform_id.channel_code))
             starttime = pick.time - prepick
-            debug_print(
-                "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,
-                debug)
+            logger.debug("Cutting {0}".format(tr.id))
             tr_cut = tr.slice(
                 starttime=starttime, endtime=starttime + length,
                 nearest_sample=False).copy()
             if len(tr_cut.data) == 0:
-                print('No data provided for %s.%s starting at %s' %
-                      (tr.stats.station, tr.stats.channel, str(starttime)))
+                logger.debug('No data provided for {0} starting at {1}'.format(
+                      tr.id, starttime))
                 continue
             # Ensure that the template is the correct length
             if len(tr_cut.data) == (tr_cut.stats.sampling_rate *
                                     length) + 1:
                 tr_cut.data = tr_cut.data[0:-1]
-            debug_print(
-                'Cut starttime = %s\nCut endtime %s' %
-                (str(tr_cut.stats.starttime), str(tr_cut.stats.endtime)), 0,
-                debug)
+            logger.debug(
+                'Cut starttime = {0}\tCut endtime {1}'.format(
+                    tr_cut.stats.starttime, tr_cut.stats.endtime))
             if min_snr is not None and \
                max(tr_cut.data) / noise_amp < min_snr:
-                print('Signal-to-noise ratio below threshold for %s.%s' %
-                      (tr_cut.stats.station, tr_cut.stats.channel))
+                logger.info('Signal-to-noise ratio below threshold for '
+                            '{0}'.format(tr.id))
                 continue
             st1 += tr_cut
             used_tr = True
         if not used_tr:
-            debug_print('No pick for ' + tr.stats.station + '.' +
-                        tr.stats.channel, 0, debug)
+            logger.info('No pick for {0}'.format(tr.id))
     if plot:
         background = stplot.trim(
             st1.sort(['starttime'])[0].stats.starttime - 10,

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -588,8 +588,8 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         # are not all zeros
         if np.all(tr.data.astype(np.float16) == 0):
             logger.warning(
-                'Trace {0} is all zeros at float16 level, either gain or check.'
-                ' Not using in template.'.format(tr.id))
+                'Trace {0} is all zeros at float16 level, either gain or '
+                'check. Not using in template.'.format(tr.id))
             st.remove(tr)
     if plot:
         stplot = st.copy()

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -191,7 +191,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     >>> templates = template_gen(
     ...    method='from_meta_file', meta_file=quakeml, st=st, lowcut=2.0,
     ...    highcut=9.0, samp_rate=20.0, filt_order=3, length=2, prepick=0.1,
-    ...    swin='S', all_horiz=True)
+    ...    swin='S', all_horiz=True, debug=4)
     >>> print(len(templates[0]))
     10
     >>> templates = template_gen(
@@ -217,8 +217,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     15
     """
     if not logger:
-        logger = debug_logger(name="eqcorrscan.core.template_gen.template_gen",
-                              debug_level=debug)
+        logger = debug_logger(name=__name__, debug_level=debug)
     client_map = {'from_client': 'fdsn', 'from_seishub': 'seishub'}
     assert method in ('from_client', 'from_seishub', 'from_meta_file',
                       'from_sac')

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -14,6 +14,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
+
 
 def debug_print(string, debug_level, print_level):
     """
@@ -33,6 +35,33 @@ def debug_print(string, debug_level, print_level):
     """
     if print_level > debug_level:
         print(string)
+
+
+def debug_logger(name, debug_level):
+    """
+    Create a logger for a function at a certain debug output level.
+
+    :type name: str
+    :param name: Function or object name
+    :type debug_level: int
+    :param debug_level: Debug level - corresponds to level of logger
+
+    :return: logging.logger
+
+    .. rubric:: Example
+    >>> logger = debug_logger("Tester", debug_level=3)
+    >>> logger.info("There is no output from info at this level")
+    >>> logger.warning("But it will log warnings") # doctest:+SKIP
+    2...- Tester - WARNING - But it will log warnings
+    """
+    logger = logging.getLogger(name=name)
+    formatter = logging.Formatter(
+        '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    ch = logging.StreamHandler()
+    ch.setFormatter(formatter)
+    ch.setLevel(debug_level * 10)
+    logger.addHandler(ch)
+    return logger
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -17,6 +17,10 @@ from __future__ import unicode_literals
 import logging
 
 
+DEBUG_MAP = {0: logging.CRITICAL, 1: logging.ERROR, 2: logging.WARNING,
+             3: logging.INFO, 4: logging.DEBUG}
+
+
 def debug_print(string, debug_level, print_level):
     """
     Print the string if the print_level exceeds the debug_level.
@@ -59,7 +63,7 @@ def debug_logger(name, debug_level):
         '%(asctime)s - %(name)s - %(levelname)s - %(message)s')
     ch = logging.StreamHandler()
     ch.setFormatter(formatter)
-    ch.setLevel(debug_level * 10)
+    ch.setLevel(DEBUG_MAP[debug_level])
     logger.addHandler(ch)
     return logger
 

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -16,14 +16,13 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import warnings
 import datetime as dt
 
 from multiprocessing import Pool, cpu_count
 
 from obspy import Stream, Trace, UTCDateTime
 from obspy.signal.filter import bandpass, lowpass, highpass
-from eqcorrscan.utils.debug_log import debug_print
+from eqcorrscan.utils.debug_log import debug_logger
 
 
 def _check_daylong(tr):
@@ -57,7 +56,7 @@ def _check_daylong(tr):
 
 def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
               parallel=False, num_cores=False, starttime=None, endtime=None,
-              seisan_chan_names=False, fill_gaps=True):
+              seisan_chan_names=False, fill_gaps=True, logger=None):
     """
     Basic function to bandpass and downsample.
 
@@ -95,6 +94,10 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
         rather than SEED convention of three) - defaults to True.
     :type fill_gaps: bool
     :param fill_gaps: Whether to pad any gaps found with zeros or not.
+    :type logger: `logging.logger`
+    :param logger:
+        Logger for output, use your own logger to allow more advanced
+        logging output.
 
     :return: Processed stream
     :rtype: :class:`obspy.core.stream.Stream`
@@ -144,6 +147,9 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
     AF.LABE..SHZ | 2013-09-01T04:10:35.700000Z - 2013-09-01T04:12:05.650000Z \
 | 20.0 Hz, 1800 samples
     """
+    if not logger:
+        debug_logger(name="eqcorrscan.utils.pre_processing.shortproc",
+                     debug_level=debug)
     if isinstance(st, Trace):
         tracein = True
         st = Stream(st)
@@ -169,8 +175,8 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
     for tr in st:
         if len(tr.data) == 0:
             st.remove(tr)
-            debug_print('No data for %s.%s after trim' %
-                        (tr.stats.station, tr.stats.channel), 1, debug)
+            logger.info('No data for {0}.{1} after trim'.format(
+                tr.stats.station, tr.stats.channel))
     if parallel:
         if not num_cores:
             num_cores = cpu_count()
@@ -181,7 +187,7 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
             'lowcut': lowcut, 'highcut': highcut, 'filt_order': filt_order,
             'samp_rate': samp_rate, 'debug': debug, 'starttime': False,
             'clip': False, 'seisan_chan_names': seisan_chan_names,
-            'fill_gaps': fill_gaps})
+            'fill_gaps': fill_gaps, 'logger': logger})
                    for tr in st]
         pool.close()
         stream_list = [p.get() for p in results]
@@ -192,7 +198,8 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
             st[i] = process(
                 tr=tr, lowcut=lowcut, highcut=highcut, filt_order=filt_order,
                 samp_rate=samp_rate, debug=debug, starttime=False, clip=False,
-                seisan_chan_names=seisan_chan_names, fill_gaps=fill_gaps)
+                seisan_chan_names=seisan_chan_names, fill_gaps=fill_gaps,
+                logger=logger)
     if tracein:
         st.merge()
         return st[0]
@@ -201,7 +208,7 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
 
 def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
             parallel=True, num_cores=False, ignore_length=False,
-            seisan_chan_names=False, fill_gaps=True):
+            seisan_chan_names=False, fill_gaps=True, logger=None):
     """
     Wrapper for dayproc to parallel multiple traces in a stream.
 
@@ -238,6 +245,10 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
         rather than SEED convention of three) - defaults to True.
     :type fill_gaps: bool
     :param fill_gaps: Whether to pad any gaps found with zeros or not.
+    :type logger: `logging.logger`
+    :param logger:
+        Logger for output, use your own logger to allow more advanced
+        logging output.
 
     :return: Processed stream.
     :rtype: :class:`obspy.core.stream.Stream`
@@ -286,6 +297,9 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
     BP.JCNB.40.SP1 | 2012-03-26T00:00:00.000000Z - 2012-03-26T23:59:59.\
 950000Z | 20.0 Hz, 1728000 samples
     """
+    if not logger:
+        debug_logger(name="eqcorrscan.utils.pre_processing.dayproc",
+                     debug_level=debug)
     # Add sanity check for filter
     if isinstance(st, Trace):
         st = Stream(st)
@@ -305,9 +319,10 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 # If the trace starts within 1 sample of the next day, use the
                 # next day as the startdate
                 startdates.append((tr.stats.starttime + 86400).date)
-                warnings.warn('%s starts within 1 sample of the next day, '
-                              'using this time %s' %
-                              (tr.id, (tr.stats.starttime + 86400).date))
+                logger.warning(
+                    '{0} starts within 1 sample of the next day, '
+                    'using this time {1}'.format(
+                        tr.id, (tr.stats.starttime + 86400).date))
             else:
                 startdates.append(tr.stats.starttime.date)
         # Check that all traces start on the same date...
@@ -324,7 +339,8 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
             'lowcut': lowcut, 'highcut': highcut, 'filt_order': filt_order,
             'samp_rate': samp_rate, 'debug': debug, 'starttime': starttime,
             'clip': True, 'ignore_length': ignore_length, 'length': 86400,
-            'seisan_chan_names': seisan_chan_names, 'fill_gaps': fill_gaps})
+            'seisan_chan_names': seisan_chan_names, 'fill_gaps': fill_gaps,
+            'logger': logger})
                    for tr in st]
         pool.close()
         stream_list = [p.get() for p in results]
@@ -336,7 +352,8 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 tr=tr, lowcut=lowcut, highcut=highcut, filt_order=filt_order,
                 samp_rate=samp_rate, debug=debug, starttime=starttime,
                 clip=True, length=86400, ignore_length=ignore_length,
-                seisan_chan_names=seisan_chan_names, fill_gaps=fill_gaps)
+                seisan_chan_names=seisan_chan_names, fill_gaps=fill_gaps,
+                logger=logger)
     if tracein:
         st.merge()
         return st[0]
@@ -345,7 +362,8 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
 
 def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
             starttime=False, clip=False, length=86400,
-            seisan_chan_names=False, ignore_length=False, fill_gaps=True):
+            seisan_chan_names=False, ignore_length=False, fill_gaps=True,
+            logger=None):
     """
     Basic function to process data, usually called by dayproc or shortproc.
 
@@ -384,10 +402,17 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
     :param ignore_length: See warning in dayproc.
     :type fill_gaps: bool
     :param fill_gaps: Whether to pad any gaps found with zeros or not.
+    :type logger: `logging.logger`
+    :param logger:
+        Logger for output, use your own logger to allow more advanced
+        logging output.
 
     :return: Processed trace.
     :type: :class:`obspy.core.stream.Trace`
     """
+    if not logger:
+        logger = debug_logger(name="eqcorrscan.utils.pre_processing.process",
+                              debug_level=debug)
     # Add sanity check
     if highcut and highcut >= 0.5 * samp_rate:
         raise IOError('Highcut must be lower than the nyquist')
@@ -402,8 +427,8 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
     else:
         day = tr.stats.starttime.date
 
-    debug_print(
-        'Working on: ' + tr.stats.station + '.' + tr.stats.channel, 2, debug)
+    logger.info('Working on: {0}.{1}'.format(
+        tr.stats.station, tr.stats.channel))
     if debug >= 5:
         tr.plot()
     # Check if the trace is gappy and pad if it is.
@@ -420,15 +445,15 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
         raise ValueError(msg)
     tr = tr.detrend('simple')
     # Detrend data before filtering
-    debug_print('I have ' + str(len(tr.data)) + ' data points for ' +
-                tr.stats.station + '.' + tr.stats.channel +
-                ' before processing', 0, debug)
+    logger.debug(
+        'There are {0} data points for {1}.{2} before processing'.format(
+            tr.stats.npts, tr.stats.station, tr.stats.channel))
 
     # Sanity check to ensure files are daylong
     padded = False
     if float(tr.stats.npts / tr.stats.sampling_rate) != length and clip:
-        debug_print('Data for ' + tr.stats.station + '.' + tr.stats.channel +
-                    ' are not of daylong length, will zero pad', 2, debug)
+        logger.info('Data for {0}.{1} are not of daylong length, will zero '
+                    'pad'.format(tr.stats.station, tr.stats.channel))
         if tr.stats.endtime - tr.stats.starttime < 0.8 * length\
            and not ignore_length:
             msg = ('Data for %s.%s is %i hours long, which is less than 0.8 '
@@ -444,14 +469,13 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
             padded = True
             pre_pad = np.zeros(int(pre_pad_secs * tr.stats.sampling_rate))
             post_pad = np.zeros(int(post_pad_secs * tr.stats.sampling_rate))
-            debug_print(str(tr), 2, debug)
-            debug_print(
-                "Padding to day long with %f s before and %f s at end" %
-                (pre_pad_secs, post_pad_secs), 1, debug)
+            logger.debug(str(tr))
+            logger.info("Padding to day long with {0} s before and {1} s at "
+                        "end".format(pre_pad_secs, post_pad_secs))
             tr.data = np.concatenate([pre_pad, tr.data, post_pad])
             # Use this rather than the expected pad because of rounding samples
             tr.stats.starttime -= len(pre_pad) * tr.stats.delta
-            debug_print(str(tr), 2, debug)
+            logger.debug(str(tr))
         # If there is one sample too many after this remove the first one
         # by convention
         if len(tr.data) == (length * tr.stats.sampling_rate) + 1:
@@ -460,55 +484,57 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
                 raise ValueError('Data are not daylong for ' +
                                  tr.stats.station + '.' + tr.stats.channel)
 
-        debug_print('I now have %i data points after enforcing length'
-                    % len(tr.data), 0, debug)
+        logger.debug('There are now {0} data points after enforcing '
+                     'length'.format(tr.stats.npts))
     # Check sampling rate and resample
     if tr.stats.sampling_rate != samp_rate:
-        debug_print('Resampling', 1, debug)
+        logger.info('Resampling')
         tr.resample(samp_rate)
     # Filtering section
     tr = tr.detrend('simple')    # Detrend data again before filtering
     if highcut and lowcut:
-        debug_print('Bandpassing', 1, debug)
+        logger.info('Bandpassing')
         tr.data = bandpass(tr.data, lowcut, highcut,
                            tr.stats.sampling_rate, filt_order, True)
     elif highcut:
-        debug_print('Lowpassing', 1, debug)
+        logger.info('Lowpassing')
         tr.data = lowpass(tr.data, highcut, tr.stats.sampling_rate,
                           filt_order, True)
     elif lowcut:
-        debug_print('Highpassing', 1, debug)
+        logger.info('Highpassing')
         tr.data = highpass(tr.data, lowcut, tr.stats.sampling_rate,
                            filt_order, True)
     else:
-        warnings.warn('No filters applied')
+        logger.warning('No filters applied')
     # Account for two letter channel names in s-files and therefore templates
     if seisan_chan_names:
         tr.stats.channel = tr.stats.channel[0] + tr.stats.channel[-1]
 
     # Sanity check the time header
     if tr.stats.starttime.day != day and clip:
-        warnings.warn("Time headers do not match expected date: " +
-                      str(tr.stats.starttime))
+        logger.warning("Time headers do not match expected date: {0}".format(
+            tr.stats.starttime))
 
     if padded:
-        debug_print("Reapplying zero pads post processing", 1, debug)
-        debug_print(str(tr), 2, debug)
+        logger.info("Reapplying zero pads post processing")
+        logger.debug(str(tr))
         pre_pad = np.zeros(int(pre_pad_secs * tr.stats.sampling_rate))
         post_pad = np.zeros(int(post_pad_secs * tr.stats.sampling_rate))
         pre_pad_len = len(pre_pad)
         post_pad_len = len(post_pad)
-        debug_print("Taking only valid data between %i and %i samples" %
-                    (pre_pad_len, len(tr.data) - post_pad_len), 1, debug)
+        logger.info(
+            "Taking only valid data between {0} and {1} samples".format(
+                pre_pad_len, tr.stats.npts - post_pad_len))
         # Re-apply the pads, taking only the data section that was valid
         tr.data = np.concatenate(
-            [pre_pad, tr.data[pre_pad_len: len(tr.data) - post_pad_len],
+            [pre_pad, tr.data[pre_pad_len: tr.stats.npts - post_pad_len],
              post_pad])
-        debug_print(str(tr), 2, debug)
+        logger.debug(str(tr))
     # Sanity check to ensure files are daylong
     if float(tr.stats.npts / tr.stats.sampling_rate) != length and clip:
-        debug_print('Data for ' + tr.stats.station + '.' + tr.stats.channel +
-                    ' are not of daylong length, will zero pad', 1, debug)
+        logger.warning(
+            'Data for {0}.{1} are not of daylong length, will zero pad'.format(
+                tr.stats.station, tr.stats.channel))
         # Use obspy's trim function with zero padding
         tr = tr.trim(starttime, starttime + length, pad=True, fill_value=0,
                      nearest_sample=True)


### PR DESCRIPTION
Work in progress on converting print statements in match-filter functions to logging. This should allow the user to provide their own logger and customise how much information is output, how it is given, and where it goes (e.g. to a file, to screen, or both).

This is at the request of @nackerley, although I have meant to do this for ages.

At the moment this does not work (as will be evidenced by failing tests).