### PR TITLE
Remove gap threshold

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 * Cleaned imports in utils modules
 * Removed parallel checking loop in archive_read.
 * Add better checks for timing in lag-calc functions (#207)
+* Removed gap-threshold of twice the template length in `Tribe.client_detect`, see
+  issue #224.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## Current
 * Cleaned imports in utils modules
 * Removed parallel checking loop in archive_read.
+* Add better checks for timing in lag-calc functions (#207)
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2515,8 +2515,8 @@ class Tribe(object):
         return party
 
     def client_detect(self, client, starttime, endtime, threshold,
-                      threshold_type, trig_int, plotvar, daylong=False,
-                      parallel_process=True, xcorr_func=None,
+                      threshold_type, trig_int, plotvar, min_gap=None,
+                      daylong=False, parallel_process=True, xcorr_func=None,
                       concurrency=None, cores=None, ignore_length=False,
                       group_size=None, debug=0, return_stream=False,
                       full_peaks=False):
@@ -2545,6 +2545,10 @@ class Tribe(object):
         :type plotvar: bool
         :param plotvar:
             Turn plotting on or off, see warning about plotting below
+        :type min_gap: float
+        :param min_gap:
+            Minimum gap allowed in data - use to remove traces with known
+            issues
         :type daylong: bool
         :param daylong:
             Set to True to use the
@@ -2690,24 +2694,24 @@ class Tribe(object):
             try:
                 st = client.get_waveforms_bulk(bulk_info)
                 # Get gaps and remove traces as necessary
-                gaps = st.get_gaps(
-                    min_gap=2 * self.templates[0].st[0].stats.npts /
-                    self.templates[0].st[0].stats.sampling_rate)
-                if len(gaps) > 0:
-                    print("Large gaps in downloaded data")
-                    st.merge()
-                    gappy_channels = list(set([(gap[0], gap[1], gap[2], gap[3])
-                                               for gap in gaps]))
-                    _st = Stream()
-                    for tr in st:
-                        tr_stats = (tr.stats.network, tr.stats.station,
-                                    tr.stats.location, tr.stats.channel)
-                        if tr_stats in gappy_channels:
-                            print("Removing gappy channel: %s" % str(tr))
-                        else:
-                            _st += tr
-                    st = _st
-                    st.split()
+                if min_gap:
+                    gaps = st.get_gaps(min_gap=min_gap)
+                    if len(gaps) > 0:
+                        print("Large gaps in downloaded data")
+                        st.merge()
+                        gappy_channels = list(
+                            set([(gap[0], gap[1], gap[2], gap[3])
+                                 for gap in gaps]))
+                        _st = Stream()
+                        for tr in st:
+                            tr_stats = (tr.stats.network, tr.stats.station,
+                                        tr.stats.location, tr.stats.channel)
+                            if tr_stats in gappy_channels:
+                                print("Removing gappy channel: %s" % str(tr))
+                            else:
+                                _st += tr
+                        st = _st
+                        st.split()
                 st.merge()
                 st.trim(starttime=starttime + (i * data_length) - pad,
                         endtime=starttime + ((i + 1) * data_length) + pad)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -503,6 +503,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     st.merge()
     # clients download chunks, we need to check that the data are
     # the desired length
+    final_channels = []
     for tr in st:
         tr.trim(starttime, endtime)
         if len(tr.data) == (process_len * tr.stats.sampling_rate) + 1:
@@ -513,10 +514,11 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
                 "percent of the desired length, will not pad".format(
                     tr.stats.station, tr.stats.channel,
                     (tr.stats.endtime - tr.stats.starttime) / 3600), 4, debug)
-            st.remove(tr)
-        if not pre_processing._check_daylong(tr):
+        elif not pre_processing._check_daylong(tr):
             print("Data are mostly zeros, removing trace: {0}".format(tr.id))
-            st.remove(tr)
+        else:
+            final_channels.append(tr)
+    st.traces = final_channels
     return st
 
 

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -126,7 +126,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     :type parallel: bool
     :param parallel: Whether to process data in parallel or not.
     :type num_cores: int
-    :param num_cores: 
+    :param num_cores:
         Number of cores to try and use, if False and parallel=True, will use
         either all your cores, or as many traces as in the data (whichever is
         smaller).

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -272,7 +272,6 @@ class TestGeoNetCase(unittest.TestCase):
         self.assertEqual(len(party), 16)
 
 
-@pytest.mark.network
 class TestGappyData(unittest.TestCase):
     @classmethod
     @pytest.mark.flaky(reruns=2)
@@ -303,6 +302,7 @@ class TestGappyData(unittest.TestCase):
             threshold_type="MAD", trig_int=2, plotvar=False,
             parallel_process=False)
         for family in party:
+            print(len(family))
             self.assertTrue(len(family) in [92, 13])
             for detection in family:
                 self.assertFalse(

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -298,12 +298,12 @@ class TestGappyData(unittest.TestCase):
         end_gap = gaps[0][5]
         party = self.tribe.client_detect(
             client=self.client, starttime=self.starttime,
-            endtime=self.endtime, threshold=10,
+            endtime=self.endtime, threshold=12,
             threshold_type="MAD", trig_int=2, plotvar=False,
             parallel_process=False)
         for family in party:
             print(len(family))
-            self.assertTrue(len(family) in [35, 1])
+            self.assertTrue(len(family) in [11, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -308,6 +308,15 @@ class TestGappyData(unittest.TestCase):
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)
 
+    def test_gappy_data_removal(self):
+        party = self.tribe.client_detect(
+            client=self.client, starttime=self.starttime,
+            endtime=self.endtime, threshold=8,
+            threshold_type="MAD", trig_int=2, plotvar=False,
+            parallel_process=False, min_gap=1)
+        self.assertEqual(len(party), 0)
+
+
 
 @pytest.mark.network
 class TestNCEDCCases(unittest.TestCase):

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -298,12 +298,12 @@ class TestGappyData(unittest.TestCase):
         end_gap = gaps[0][5]
         party = self.tribe.client_detect(
             client=self.client, starttime=self.starttime,
-            endtime=self.endtime, threshold=8,
+            endtime=self.endtime, threshold=10,
             threshold_type="MAD", trig_int=2, plotvar=False,
             parallel_process=False)
         for family in party:
             print(len(family))
-            self.assertTrue(len(family) in [92, 13])
+            self.assertTrue(len(family) in [35, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)


### PR DESCRIPTION
Closes #224 

The gap threshold seemed a little arbitrary and very short. @nackerley pointed this out when working on his own data and making his own method that allowed him to take data from multiple clients. Tests pass locally, but I haven't done anything special.

This needs:
~~- [x] A test with known gappy data to ensure that we don't get warnings of low variance from the underlying C-code~~
~~- [ ] Make a test that actually captures that output, or pass it back to Python properly...~~

These are handled by the `correlate.py` function now (see #230)

- [x] Test for gappy data from client - I don't know where this might come from.