### PR TITLE
WIP: Use logging

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   is the same value repeated (#224, #230).
 * BUG-FIX: template generation `from_client` methods for swin=P_all or S_all
   now download all channels and return them (as they should). See #235 and #206
+* Change standard debug printing to logging (#229).
+* Change from raising an error if data from a station are not long enough, to
+  logging a critical warning and not using the station.
+* Add ability to give multiple `swin` options as a list. Remains backwards
+  compatible with single `swin` arguments.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -41,7 +41,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import warnings
 import numpy as np
 import copy
 
@@ -215,6 +214,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     client_map = {'from_client': 'fdsn', 'from_seishub': 'seishub'}
     assert method in ('from_client', 'from_seishub', 'from_meta_file',
                       'from_sac')
+    if not isinstance(swin, list):
+        swin = [swin]
     process = True
     if method in ['from_client', 'from_seishub']:
         catalog = kwargs.get('catalog', Catalog())
@@ -256,7 +257,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     temp_list = []
     process_lengths = []
 
-    if swin in ["P_all", "S_all"]:
+    if "P_all" in swin or "S_all" in swin or all_horiz:
         all_channels = True
     else:
         all_channels = False
@@ -299,7 +300,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         for event in sub_catalog:
             stations, channels, st_stachans = ([], [], [])
             if len(event.picks) == 0:
-                warnings.warn('No picks for event %s' % event.resource_id)
+                debug_print('No picks for event {0}'.format(event.resource_id),
+                            2, debug)
                 continue
             use_event = True
             # Check that the event is within the data
@@ -311,14 +313,15 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                                  str(data_end)), 0, debug)
                     use_event = False
             if not use_event:
-                warnings.warn('Event is not within data time-span')
+                debug_print('Event is not within data time-span', 2, debug)
                 continue
             # Read in pick info
             debug_print("I have found the following picks", 0, debug)
             for pick in event.picks:
                 if not pick.waveform_id:
-                    print('Pick not associated with waveforms, will not use.')
-                    print(pick)
+                    debug_print(
+                        'Pick not associated with waveforms, will not use:'
+                        ' {0}'.format(pick), 1, debug)
                     continue
                 debug_print(pick, 0, debug)
                 stations.append(pick.waveform_id.station_code)
@@ -414,9 +417,9 @@ def extract_from_stack(stack, template, length, pre_pick, pre_pad,
         if Z_include and len(delay) == 0:
             delay = [d[2] for d in delays if d[0] == tr.stats.station]
         if len(delay) == 0:
-            msg = ' '.join(['No matching template channel found for stack',
-                            'channel', tr.stats.station, tr.stats.channel])
-            warnings.warn(msg)
+            debug_print("No matching template channel found for stack channel"
+                        " {0}.{1}".format(tr.stats.station, tr.stats.channel),
+                        2, 3)
             new_template.remove(tr)
         else:
             for d in delay:
@@ -470,7 +473,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
             st += client.get_waveforms(net, sta, loc, chan,
                                        starttime, endtime)
         except Exception:
-            warnings.warn('Found no data for this station')
+            debug_print('Found no data for this station', 2, debug)
             dropped_pick_stations += 1
     if not st and dropped_pick_stations == len(event.picks):
         raise Exception('No data available, is the server down?')
@@ -558,7 +561,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     from eqcorrscan.core.bright_lights import _rms
     picks_copy = copy.deepcopy(picks)  # Work on a copy of the picks and leave
     # the users picks intact.
-    assert swin in ['P', 'all', 'S', 'P_all', 'S_all']
+    if not isinstance(swin, list):
+        swin = [swin]
+    for _swin in swin:
+        assert _swin in ['P', 'all', 'S', 'P_all', 'S_all']
     for pick in picks_copy:
         if not pick.waveform_id:
             print('Pick not associated with waveform, will not use it.')
@@ -579,69 +585,74 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         # Check that the data can be represented by float16, and check they
         # are not all zeros
         if np.all(tr.data.astype(np.float16) == 0):
-            warnings.warn('Trace is all zeros at float16 level,'
-                          'either gain or check. Not using in template.')
-            print(tr)
+            debug_print("Trace is all zeros at float16 level, either gain or "
+                        "check. Not using in template: {0}".format(tr), 4,
+                        debug)
             st.remove(tr)
-    if plot:
-        stplot = st.copy()
     # Get the earliest pick-time and use that if we are not using delayed.
     picks_copy.sort(key=lambda p: p.time)
     first_pick = picks_copy[0]
+    if plot:
+        stplot = st.slice(first_pick.time - 20,
+                          first_pick.time + length + 90).copy()
     # Work out starttimes
     starttimes = []
-    for tr in st:
-        starttime = {'station': tr.stats.station, 'channel': tr.stats.channel,
-                     'picks': []}
-        station_picks = [pick for pick in picks_copy
-                         if pick.waveform_id.station_code == tr.stats.station]
-        if swin == 'P_all':
-            p_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'P']
-            if len(p_pick) == 0:
-                continue
-            starttime.update({'picks': p_pick})
-        if swin == 'S_all':
-            s_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'S']
-            if len(s_pick) == 0:
-                continue
-            starttime.update({'picks': s_pick})
-        if swin == 'all':
-            if all_horiz and tr.stats.channel[-1] in ['1', '2', '3', 'N', 'E']:
-                # Get all picks on horizontal channels
-                channel_pick = [
-                    pick for pick in station_picks
-                    if pick.waveform_id.channel_code[-1] in
-                    ['1', '2', '3', 'N', 'E']]
-            else:
-                channel_pick = [
-                    pick for pick in station_picks
-                    if pick.waveform_id.channel_code == tr.stats.channel]
-            if len(channel_pick) == 0:
-                continue
-            starttime.update({'picks': channel_pick})
-        if swin == 'P':
-            p_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'P' and
-                      pick.waveform_id.channel_code == tr.stats.channel]
-            if len(p_pick) == 0:
-                continue
-            starttime.update({'picks': p_pick})
-        if swin == 'S':
-            if tr.stats.channel[-1] in ['Z', 'U']:
-                continue
-            s_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'S']
-            if not all_horiz:
-                s_pick = [pick for pick in s_pick
-                          if pick.waveform_id.channel_code == tr.stats.channel]
-            starttime.update({'picks': s_pick})
-            if len(starttime['picks']) == 0:
-                continue
-        if not delayed:
-            starttime.update({'picks': [first_pick]})
-        starttimes.append(starttime)
+    for _swin in swin:
+        for tr in st:
+            starttime = {'station': tr.stats.station,
+                         'channel': tr.stats.channel, 'picks': []}
+            station_picks = [pick for pick in picks_copy
+                             if pick.waveform_id.station_code ==
+                             tr.stats.station]
+            if _swin == 'P_all':
+                p_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'P']
+                if len(p_pick) == 0:
+                    continue
+                starttime.update({'picks': p_pick})
+            elif _swin == 'S_all':
+                s_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'S']
+                if len(s_pick) == 0:
+                    continue
+                starttime.update({'picks': s_pick})
+            elif _swin == 'all':
+                if all_horiz and tr.stats.channel[-1] in ['1', '2', '3',
+                                                          'N', 'E']:
+                    # Get all picks on horizontal channels
+                    channel_pick = [
+                        pick for pick in station_picks
+                        if pick.waveform_id.channel_code[-1] in
+                        ['1', '2', '3', 'N', 'E']]
+                else:
+                    channel_pick = [
+                        pick for pick in station_picks
+                        if pick.waveform_id.channel_code == tr.stats.channel]
+                if len(channel_pick) == 0:
+                    continue
+                starttime.update({'picks': channel_pick})
+            elif _swin == 'P':
+                p_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'P' and
+                          pick.waveform_id.channel_code == tr.stats.channel]
+                if len(p_pick) == 0:
+                    continue
+                starttime.update({'picks': p_pick})
+            elif _swin == 'S':
+                if tr.stats.channel[-1] in ['Z', 'U']:
+                    continue
+                s_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'S']
+                if not all_horiz:
+                    s_pick = [pick for pick in s_pick
+                              if pick.waveform_id.channel_code ==
+                              tr.stats.channel]
+                starttime.update({'picks': s_pick})
+                if len(starttime['picks']) == 0:
+                    continue
+            if not delayed:
+                starttime.update({'picks': [first_pick]})
+            starttimes.append(starttime)
     # Cut the data
     st1 = Stream()
     for _starttime in starttimes:
@@ -656,11 +667,11 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                msg = ('Pick for ' + pick.waveform_id.station_code + '.' +
-                       pick.waveform_id.channel_code + ' has no phase ' +
-                       'hint given, you should not use this template for ' +
-                       'cross-correlation re-picking!')
-                warnings.warn(msg)
+                debug_print("Pick for {0}.{1} has no phase hint given, you "
+                            "should not use this template for cross-correlation"
+                            " re-picking!".format(
+                    pick.waveform_id.station_code,
+                    pick.waveform_id.channel_code), 2, debug)
             starttime = pick.time - prepick
             debug_print(
                 "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,
@@ -691,10 +702,7 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
             debug_print('No pick for ' + tr.stats.station + '.' +
                         tr.stats.channel, 0, debug)
     if plot:
-        background = stplot.trim(
-            st1.sort(['starttime'])[0].stats.starttime - 10,
-            st1.sort(['starttime'])[-1].stats.endtime + 10)
-        tplot(st1, background=background, picks=picks_copy,
+        tplot(st1, background=stplot, picks=picks_copy,
               title='Template for ' + str(st1[0].stats.starttime))
         del stplot
     return st1

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -263,6 +263,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         all_channels = False
     for sub_catalog in sub_catalogs:
         if method in ['from_seishub', 'from_client']:
+            debug_print("Downloading data", 1, debug)
             st = _download_from_client(
                 client=client, client_type=client_map[method],
                 catalog=sub_catalog, data_pad=data_pad,
@@ -573,7 +574,7 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 "{0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
-        if not pick.waveform_id.station_code or pick.waveform_id.channel_code:
+        if not pick.waveform_id.station_code or not pick.waveform_id.channel_code:
             debug_print(
                 "Pick not associated with a channel, will not use it:"
                 " {0}".format(pick), 1, debug)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -441,8 +441,9 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     for event in catalog:
         for pick in event.picks:
             if not pick.waveform_id:
-                print('Pick not associated with waveforms, will not use.')
-                print(pick)
+                debug_print(
+                    "Pick not associated with waveforms, will not use:"
+                    " {0}".format(pick), 1, debug)
                 continue
             if all_channels:
                 channel_code = pick.waveform_id.channel_code[0:2] + "?"
@@ -567,18 +568,15 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         assert _swin in ['P', 'all', 'S', 'P_all', 'S_all']
     for pick in picks_copy:
         if not pick.waveform_id:
-            print('Pick not associated with waveform, will not use it.')
-            print(pick)
+            debug_print(
+                "Pick not associated with waveform, will not use it: "
+                "{0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
-        if not pick.waveform_id.station_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
-            picks_copy.remove(pick)
-            continue
-        if not pick.waveform_id.channel_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
+        if not pick.waveform_id.station_code or pick.waveform_id.channel_code:
+            debug_print(
+                "Pick not associated with a channel, will not use it:"
+                " {0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
     for tr in st:
@@ -681,8 +679,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 starttime=starttime, endtime=starttime + length,
                 nearest_sample=False).copy()
             if len(tr_cut.data) == 0:
-                print('No data provided for %s.%s starting at %s' %
-                      (tr.stats.station, tr.stats.channel, str(starttime)))
+                debug_print(
+                    "No data provided for {0}.{1} starting at {2}".format(
+                        tr.stats.station, tr.stats.channel, starttime), 3,
+                    debug)
                 continue
             # Ensure that the template is the correct length
             if len(tr_cut.data) == (tr_cut.stats.sampling_rate *
@@ -694,8 +694,9 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 debug)
             if min_snr is not None and \
                max(tr_cut.data) / noise_amp < min_snr:
-                print('Signal-to-noise ratio below threshold for %s.%s' %
-                      (tr_cut.stats.station, tr_cut.stats.channel))
+                debug_print(
+                    "Signal-to-noise ratio below threshold for {0}.{1}".format(
+                        tr_cut.stats.station, tr_cut.stats.channel), 3, debug)
                 continue
             st1 += tr_cut
             used_tr = True

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -667,11 +667,12 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                debug_print("Pick for {0}.{1} has no phase hint given, you "
-                            "should not use this template for cross-correlation"
-                            " re-picking!".format(
-                    pick.waveform_id.station_code,
-                    pick.waveform_id.channel_code), 2, debug)
+                debug_print(
+                    "Pick for {0}.{1} has no phase hint given, you should not "
+                    "use this template for cross-correlation"
+                    " re-picking!".format(
+                        pick.waveform_id.station_code,
+                        pick.waveform_id.channel_code), 2, debug)
             starttime = pick.time - prepick
             debug_print(
                 "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -14,8 +14,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 
-def debug_print(string, debug_level, print_level):
+LOG = {0: logging.debug, 1: logging.info, 2: logging.warning, 3: logging.error,
+       4: logging.critical}
+
+
+def debug_print(string, debug_level, print_level, use_logging=True):
     """
     Print the string if the print_level exceeds the debug_level.
 
@@ -25,14 +30,21 @@ def debug_print(string, debug_level, print_level):
     :param print_level: Print-level for statement
     :type debug_level: int
     :param debug_level: Output level for function
+    :type use_logging: bool
+    :param use_logging: Uses logging to output information
 
     .. rubric:: Example
-    >>> debug_print("Albert", 2, 0)
-    >>> debug_print("Norman", 0, 2)
+    >>> debug_print("Albert", 2, 0, use_logging=False)
+    >>> debug_print("Norman", 0, 2, use_logging=False)
     Norman
     """
-    if print_level > debug_level:
+    if not use_logging and print_level > debug_level:
         print(string)
+    if use_logging:
+        try:
+            LOG[print_level](string)
+        except IndexError:
+            LOG[4](string)
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -42,7 +42,7 @@ def debug_print(string, debug_level, print_level, use_logging=True):
         print(string)
     if use_logging:
         try:
-            LOG[print_level](string)
+            LOG[debug_level](string)
         except IndexError:
             LOG[4](string)
 

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import warnings
 import datetime as dt
 
 from multiprocessing import Pool, cpu_count
@@ -305,9 +304,10 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 # If the trace starts within 1 sample of the next day, use the
                 # next day as the startdate
                 startdates.append((tr.stats.starttime + 86400).date)
-                warnings.warn('%s starts within 1 sample of the next day, '
-                              'using this time %s' %
-                              (tr.id, (tr.stats.starttime + 86400).date))
+                debug_print(
+                    '{0} starts within 1 sample of the next day, using this '
+                    'time {1}'.format(tr.id, (tr.stats.starttime + 86400).date),
+                    2, debug)
             else:
                 startdates.append(tr.stats.starttime.date)
         # Check that all traces start on the same date...
@@ -481,15 +481,15 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
         tr.data = highpass(tr.data, lowcut, tr.stats.sampling_rate,
                            filt_order, True)
     else:
-        warnings.warn('No filters applied')
+        debug_print('No filters applied', 2, debug)
     # Account for two letter channel names in s-files and therefore templates
     if seisan_chan_names:
         tr.stats.channel = tr.stats.channel[0] + tr.stats.channel[-1]
 
     # Sanity check the time header
     if tr.stats.starttime.day != day and clip:
-        warnings.warn("Time headers do not match expected date: " +
-                      str(tr.stats.starttime))
+        debug_print("Time headers do not match expected date: {0}".format(
+            tr.stats.starttime), 2, debug)
 
     if padded:
         debug_print("Reapplying zero pads post processing", 1, debug)

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -306,8 +306,8 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 startdates.append((tr.stats.starttime + 86400).date)
                 debug_print(
                     '{0} starts within 1 sample of the next day, using this '
-                    'time {1}'.format(tr.id, (tr.stats.starttime + 86400).date),
-                    2, debug)
+                    'time {1}'.format(
+                        tr.id, (tr.stats.starttime + 86400).date), 2, debug)
             else:
                 startdates.append(tr.stats.starttime.date)
         # Check that all traces start on the same date...

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -529,7 +529,7 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
     # Final visual check for debug
     if debug > 4:
         tr.plot()
-    return tr, True
+    return tr
 
 
 def _zero_pad_gaps(tr, gaps, fill_gaps=True):


### PR DESCRIPTION
This superseeds #225.

This attempt does not pass `Logger`'s between processes, rather using the root logger.  The user should be able to set up the root logger themselves, but it needs to be *documented*.

Currently this probably overloads the settings of `level` and `format` that a user would set internally, open to discussion about whether this should be done, or, if there is a way to check if the level and format has already been set.  If it has already been set, then it doesn't make sense to reset it.

Setting up the root logger can be done something like:
```python
import logging

rootLogger = logging.getLogger()
rootLogger.setLevel("debug") # Options are debug, info, warning, error, critical
# Create a fileHandler to log output to file
fh = logging.FileHandler('eqcorrscan.log')
fh.setLevel(logging.DEBUG)
# create console handler with a higher log level
ch = logging.StreamHandler()
ch.setLevel(logging.ERROR)
# create formatter and add it to the handlers
formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
fh.setFormatter(formatter)
ch.setFormatter(formatter)
# add the handlers to the logger
rootLogger.addHandler(fh)
rootLogger.addHandler(ch)
```

So, things to do on this are:
- [ ] Check whether the logger has already been set-up and don't overload those settings internally
- [ ] Add docs on how to set up a logger - link to [logging cookbook](https://docs.python.org/3/howto/logging-cookbook.html)
- [ ] Convert remaining print statements to logging statements in the `core` functions and those called by the `core` functions
- [x] Consider how to better warn of low variance from C-code (see #224)

This PR also adds the option of multiple `swin` arguments and removes the error when data are too short (instead data are removed). This needs to be:
- [ ] documented;
- [ ] tested.