### PR TITLE
Add limits to findpeaks parallel processing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 * Cleaned imports in utils modules
 * Removed parallel checking loop in archive_read.
 * Add better checks for timing in lag-calc functions (#207)
+* Bug-fix: give multi_find_peaks a cores kwarg to limit thread
+  usage.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -4136,7 +4136,7 @@ def match_filter(template_names, template_list, st, threshold,
     all_peaks = multi_find_peaks(
         arr=cccsums, thresh=thresholds, debug=debug, parallel=parallel,
         trig_int=int(trig_int * stream[0].stats.sampling_rate),
-        full_peaks=full_peaks)
+        full_peaks=full_peaks, cores=cores)
     for i, cccsum in enumerate(cccsums):
         if np.abs(np.mean(cccsum)) > 0.05:
             warnings.warn('Mean is not zero!  Check this!')

--- a/eqcorrscan/utils/findpeaks.py
+++ b/eqcorrscan/utils/findpeaks.py
@@ -168,7 +168,8 @@ def find_peaks2_short(arr, thresh, trig_int, debug=0, starttime=False,
 
 
 def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
-                     samp_rate=1.0, parallel=True, full_peaks=False):
+                     samp_rate=1.0, parallel=True, full_peaks=False,
+                     cores=None):
     """
     Wrapper for find-peaks for multiple arrays.
 
@@ -192,6 +193,8 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
         Whether to compute in parallel or not - will use multiprocessing
     :type full_peaks: bool
     :param full_peaks: See `eqcorrscan.utils.findpeaks.find_peaks2_short`
+    :type cores: int
+    :param cores: Number of processes to spool for parallel peak finding.
 
     :returns:
         List of list of tuples of (peak, index) in same order as input arrays
@@ -204,7 +207,9 @@ def multi_find_peaks(arr, thresh, trig_int, debug=0, starttime=False,
                 starttime=starttime, samp_rate=samp_rate,
                 full_peaks=full_peaks))
     else:
-        with pool_boy(Pool=Pool, traces=arr.shape[0]) as pool:
+        if cores is None:
+            cores = arr.shape[0]
+        with pool_boy(Pool=Pool, traces=cores) as pool:
             params = ((sub_arr, arr_thresh, trig_int, debug,
                        False, 1.0, full_peaks)
                       for sub_arr, arr_thresh in zip(arr, thresh))


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

This PR adds a `cores` kwarg to `eqcorrscan.utils.findpeaks.multi_find_peaks` to limit CPU usage.

### Why was it initiated?  Any relevant Issues?

This became an issue with not being able to allocate enough memory on an 80 CPU multi-core machine.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `develop` for bug fixes.
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~~- [ ] Any new features or fixed regressions are be covered via new tests.~~
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
