### PR TITLE
Patch client methods

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,6 @@
   is the same value repeated (#224, #230).
 * BUG-FIX: template generation `from_client` methods for swin=P_all or S_all
   now download all channels and return them (as they should). See #235 and #206
-* Change standard debug printing to logging (#229).
 * Change from raising an error if data from a station are not long enough, to
   logging a critical warning and not using the station.
 * Add ability to give multiple `swin` options as a list. Remains backwards

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
   logging a critical warning and not using the station.
 * Add ability to give multiple `swin` options as a list. Remains backwards
   compatible with single `swin` arguments.
+* Add option to `save_progress` for long running `Tribe` methods. Files
+  are written to temporary files local to the caller.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@
   compatible with single `swin` arguments.
 * Add option to `save_progress` for long running `Tribe` methods. Files
   are written to temporary files local to the caller.
+* Fix bug where if gaps overlapped the endtime set in pre_processing an error
+  was raised - happened when downloading data with a deliberate pad at either
+  end.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
   is the same value repeated (#224, #230).
 * BUG-FIX: template generation `from_client` methods for swin=P_all or S_all
   now download all channels and return them (as they should). See #235 and #206
+* Change standard debug printing to logging (#229).
+* Change from raising an error if data from a station are not long enough, to
+  logging a critical warning and not using the station.
+* Add ability to give multiple `swin` options as a list. Remains backwards
+  compatible with single `swin` arguments.
 
 ## 0.3.0
 * Compiled peak-finding routine written to speed-up peak-finding.

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2750,7 +2750,7 @@ class Tribe(object):
             return party
 
     def construct(self, method, lowcut, highcut, samp_rate, filt_order,
-                  prepick, save_progress, **kwargs):
+                  prepick, save_progress=False, **kwargs):
         """
         Generate a Tribe of Templates.
 

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2339,7 +2339,7 @@ class Tribe(object):
                daylong=False, parallel_process=True, xcorr_func=None,
                concurrency=None, cores=None, ignore_length=False,
                group_size=None, overlap="calculate", debug=0,
-               full_peaks=False):
+               full_peaks=False, save_progress=False):
         """
         Detect using a Tribe of templates within a continuous stream.
 
@@ -2404,6 +2404,10 @@ class Tribe(object):
             4 and 5, detections will not be computed in parallel.
         :type full_peaks: bool
         :param full_peaks: See `eqcorrscan.utils.findpeak.find_peaks2_short`
+        :type save_progress: bool
+        :param save_progress: 
+            Whether to save the resulting party at every data step or not.
+            Useful for long-running processes.
 
         :return:
             :class:`eqcorrscan.core.match_filter.Party` of Families of
@@ -2507,6 +2511,8 @@ class Tribe(object):
                 ignore_length=ignore_length, overlap=overlap, debug=debug,
                 full_peaks=full_peaks)
             party += group_party
+            if save_progress:
+                party.write("eqcorrscan_temporary_party")
         if len(party) > 0:
             for family in party:
                 if family is not None:
@@ -2519,7 +2525,7 @@ class Tribe(object):
                       parallel_process=True, xcorr_func=None,
                       concurrency=None, cores=None, ignore_length=False,
                       group_size=None, debug=0, return_stream=False,
-                      full_peaks=False):
+                      full_peaks=False, save_progress=False):
         """
         Detect using a Tribe of templates within a continuous stream.
 
@@ -2577,6 +2583,10 @@ class Tribe(object):
             consumption, if unset will use all templates.
         :type full_peaks: bool
         :param full_peaks: See `eqcorrscan.utils.findpeaks.find_peaks2_short`
+        :type save_progress: bool
+        :param save_progress: 
+            Whether to save the resulting party at every data step or not.
+            Useful for long-running processes.
 
         :type debug: int
         :param debug:
@@ -2721,6 +2731,8 @@ class Tribe(object):
                     concurrency=concurrency, cores=cores,
                     ignore_length=ignore_length, group_size=group_size,
                     overlap=None, debug=debug, full_peaks=full_peaks)
+                if save_progress:
+                    party.write("eqcorrscan_temporary_party")
             except Exception as e:
                 print('Error, routine incomplete, returning incomplete Party')
                 print('Error: %s' % str(e))
@@ -2738,7 +2750,7 @@ class Tribe(object):
             return party
 
     def construct(self, method, lowcut, highcut, samp_rate, filt_order,
-                  prepick, **kwargs):
+                  prepick, save_progress, **kwargs):
         """
         Generate a Tribe of Templates.
 
@@ -2760,6 +2772,10 @@ class Tribe(object):
             Filter level (number of corners).
         :type prepick: float
         :param prepick: Pre-pick time in seconds
+        :type save_progress: bool
+        :param save_progress: 
+            Whether to save the resulting party at every data step or not.
+            Useful for long-running processes.
 
         .. Note::
             Methods: `from_contbase`, `from_sfile` and `from_sac` are not
@@ -2775,7 +2791,7 @@ class Tribe(object):
         templates, catalog, process_lengths = template_gen.template_gen(
             method=method, lowcut=lowcut, highcut=highcut,
             filt_order=filt_order, samp_rate=samp_rate, prepick=prepick,
-            return_event=True, **kwargs)
+            return_event=True, save_progress=save_progress, **kwargs)
         for template, event, process_len in zip(templates, catalog,
                                                 process_lengths):
             t = Template()

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2405,7 +2405,7 @@ class Tribe(object):
         :type full_peaks: bool
         :param full_peaks: See `eqcorrscan.utils.findpeak.find_peaks2_short`
         :type save_progress: bool
-        :param save_progress: 
+        :param save_progress:
             Whether to save the resulting party at every data step or not.
             Useful for long-running processes.
 
@@ -2584,7 +2584,7 @@ class Tribe(object):
         :type full_peaks: bool
         :param full_peaks: See `eqcorrscan.utils.findpeaks.find_peaks2_short`
         :type save_progress: bool
-        :param save_progress: 
+        :param save_progress:
             Whether to save the resulting party at every data step or not.
             Useful for long-running processes.
 
@@ -2773,7 +2773,7 @@ class Tribe(object):
         :type prepick: float
         :param prepick: Pre-pick time in seconds
         :type save_progress: bool
-        :param save_progress: 
+        :param save_progress:
             Whether to save the resulting party at every data step or not.
             Useful for long-running processes.
 

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -125,7 +125,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     :type parallel: bool
     :param parallel: Whether to process data in parallel or not.
     :type save_progress: bool
-    :param save_progress: 
+    :param save_progress:
         Whether to save the resulting party at every data step or not.
         Useful for long-running processes.
 
@@ -593,7 +593,8 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 "{0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
-        if not pick.waveform_id.station_code or not pick.waveform_id.channel_code:
+        if not pick.waveform_id.station_code or not \
+                pick.waveform_id.channel_code:
             debug_print(
                 "Pick not associated with a channel, will not use it:"
                 " {0}".format(pick), 1, debug)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -492,12 +492,19 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     if not st and dropped_pick_stations == len(event.picks):
         raise Exception('No data available, is the server down?')
     st.merge()
-    # clients download chunks, we need to assert that the data are
+    # clients download chunks, we need to check that the data are
     # the desired length
     for tr in st:
         tr.trim(starttime, endtime)
         if len(tr.data) == (process_len * tr.stats.sampling_rate) + 1:
             tr.data = tr.data[1:len(tr.data)]
+        if tr.stats.endtime - tr.stats.starttime < 0.8 * process_len:
+            debug_print(
+                "Data for {0}.{1} is {2} hours long, which is less than 80 "
+                "percent of the desired length, will not pad".format(
+                    tr.stats.station, tr.stats.channel,
+                    (tr.stats.endtime - tr.stats.starttime) / 3600), 4, debug)
+            st.remove(tr)
     return st
 
 

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -41,7 +41,6 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import warnings
 import numpy as np
 import copy
 
@@ -215,6 +214,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     client_map = {'from_client': 'fdsn', 'from_seishub': 'seishub'}
     assert method in ('from_client', 'from_seishub', 'from_meta_file',
                       'from_sac')
+    if not isinstance(swin, list):
+        swin = [swin]
     process = True
     if method in ['from_client', 'from_seishub']:
         catalog = kwargs.get('catalog', Catalog())
@@ -256,7 +257,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     temp_list = []
     process_lengths = []
 
-    if swin in ["P_all", "S_all"]:
+    if "P_all" in swin or "S_all" in swin or all_horiz:
         all_channels = True
     else:
         all_channels = False
@@ -299,7 +300,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         for event in sub_catalog:
             stations, channels, st_stachans = ([], [], [])
             if len(event.picks) == 0:
-                warnings.warn('No picks for event %s' % event.resource_id)
+                debug_print('No picks for event {0}'.format(event.resource_id),
+                            2, debug)
                 continue
             use_event = True
             # Check that the event is within the data
@@ -311,14 +313,15 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                                  str(data_end)), 0, debug)
                     use_event = False
             if not use_event:
-                warnings.warn('Event is not within data time-span')
+                debug_print('Event is not within data time-span', 2, debug)
                 continue
             # Read in pick info
             debug_print("I have found the following picks", 0, debug)
             for pick in event.picks:
                 if not pick.waveform_id:
-                    print('Pick not associated with waveforms, will not use.')
-                    print(pick)
+                    debug_print(
+                        'Pick not associated with waveforms, will not use:'
+                        ' {0}'.format(pick), 1, debug)
                     continue
                 debug_print(pick, 0, debug)
                 stations.append(pick.waveform_id.station_code)
@@ -414,9 +417,9 @@ def extract_from_stack(stack, template, length, pre_pick, pre_pad,
         if Z_include and len(delay) == 0:
             delay = [d[2] for d in delays if d[0] == tr.stats.station]
         if len(delay) == 0:
-            msg = ' '.join(['No matching template channel found for stack',
-                            'channel', tr.stats.station, tr.stats.channel])
-            warnings.warn(msg)
+            debug_print("No matching template channel found for stack channel"
+                        " {0}.{1}".format(tr.stats.station, tr.stats.channel),
+                        2, 3)
             new_template.remove(tr)
         else:
             for d in delay:
@@ -470,7 +473,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
             st += client.get_waveforms(net, sta, loc, chan,
                                        starttime, endtime)
         except Exception:
-            warnings.warn('Found no data for this station')
+            debug_print('Found no data for this station', 2, debug)
             dropped_pick_stations += 1
     if not st and dropped_pick_stations == len(event.picks):
         raise Exception('No data available, is the server down?')
@@ -558,7 +561,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     from eqcorrscan.core.bright_lights import _rms
     picks_copy = copy.deepcopy(picks)  # Work on a copy of the picks and leave
     # the users picks intact.
-    assert swin in ['P', 'all', 'S', 'P_all', 'S_all']
+    if not isinstance(swin, list):
+        swin = [swin]
+    for _swin in swin:
+        assert _swin in ['P', 'all', 'S', 'P_all', 'S_all']
     for pick in picks_copy:
         if not pick.waveform_id:
             print('Pick not associated with waveform, will not use it.')
@@ -579,69 +585,74 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         # Check that the data can be represented by float16, and check they
         # are not all zeros
         if np.all(tr.data.astype(np.float16) == 0):
-            warnings.warn('Trace is all zeros at float16 level,'
-                          'either gain or check. Not using in template.')
-            print(tr)
+            debug_print("Trace is all zeros at float16 level, either gain or "
+                        "check. Not using in template: {0}".format(tr), 4,
+                        debug)
             st.remove(tr)
-    if plot:
-        stplot = st.copy()
     # Get the earliest pick-time and use that if we are not using delayed.
     picks_copy.sort(key=lambda p: p.time)
     first_pick = picks_copy[0]
+    if plot:
+        stplot = st.slice(first_pick.time - 20,
+                          first_pick.time + length + 90).copy()
     # Work out starttimes
     starttimes = []
-    for tr in st:
-        starttime = {'station': tr.stats.station, 'channel': tr.stats.channel,
-                     'picks': []}
-        station_picks = [pick for pick in picks_copy
-                         if pick.waveform_id.station_code == tr.stats.station]
-        if swin == 'P_all':
-            p_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'P']
-            if len(p_pick) == 0:
-                continue
-            starttime.update({'picks': p_pick})
-        if swin == 'S_all':
-            s_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'S']
-            if len(s_pick) == 0:
-                continue
-            starttime.update({'picks': s_pick})
-        if swin == 'all':
-            if all_horiz and tr.stats.channel[-1] in ['1', '2', '3', 'N', 'E']:
-                # Get all picks on horizontal channels
-                channel_pick = [
-                    pick for pick in station_picks
-                    if pick.waveform_id.channel_code[-1] in
-                    ['1', '2', '3', 'N', 'E']]
-            else:
-                channel_pick = [
-                    pick for pick in station_picks
-                    if pick.waveform_id.channel_code == tr.stats.channel]
-            if len(channel_pick) == 0:
-                continue
-            starttime.update({'picks': channel_pick})
-        if swin == 'P':
-            p_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'P' and
-                      pick.waveform_id.channel_code == tr.stats.channel]
-            if len(p_pick) == 0:
-                continue
-            starttime.update({'picks': p_pick})
-        if swin == 'S':
-            if tr.stats.channel[-1] in ['Z', 'U']:
-                continue
-            s_pick = [pick for pick in station_picks
-                      if pick.phase_hint.upper()[0] == 'S']
-            if not all_horiz:
-                s_pick = [pick for pick in s_pick
-                          if pick.waveform_id.channel_code == tr.stats.channel]
-            starttime.update({'picks': s_pick})
-            if len(starttime['picks']) == 0:
-                continue
-        if not delayed:
-            starttime.update({'picks': [first_pick]})
-        starttimes.append(starttime)
+    for _swin in swin:
+        for tr in st:
+            starttime = {'station': tr.stats.station,
+                         'channel': tr.stats.channel, 'picks': []}
+            station_picks = [pick for pick in picks_copy
+                             if pick.waveform_id.station_code ==
+                             tr.stats.station]
+            if _swin == 'P_all':
+                p_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'P']
+                if len(p_pick) == 0:
+                    continue
+                starttime.update({'picks': p_pick})
+            elif _swin == 'S_all':
+                s_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'S']
+                if len(s_pick) == 0:
+                    continue
+                starttime.update({'picks': s_pick})
+            elif _swin == 'all':
+                if all_horiz and tr.stats.channel[-1] in ['1', '2', '3',
+                                                          'N', 'E']:
+                    # Get all picks on horizontal channels
+                    channel_pick = [
+                        pick for pick in station_picks
+                        if pick.waveform_id.channel_code[-1] in
+                        ['1', '2', '3', 'N', 'E']]
+                else:
+                    channel_pick = [
+                        pick for pick in station_picks
+                        if pick.waveform_id.channel_code == tr.stats.channel]
+                if len(channel_pick) == 0:
+                    continue
+                starttime.update({'picks': channel_pick})
+            elif _swin == 'P':
+                p_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'P' and
+                          pick.waveform_id.channel_code == tr.stats.channel]
+                if len(p_pick) == 0:
+                    continue
+                starttime.update({'picks': p_pick})
+            elif _swin == 'S':
+                if tr.stats.channel[-1] in ['Z', 'U']:
+                    continue
+                s_pick = [pick for pick in station_picks
+                          if pick.phase_hint.upper()[0] == 'S']
+                if not all_horiz:
+                    s_pick = [pick for pick in s_pick
+                              if pick.waveform_id.channel_code ==
+                              tr.stats.channel]
+                starttime.update({'picks': s_pick})
+                if len(starttime['picks']) == 0:
+                    continue
+            if not delayed:
+                starttime.update({'picks': [first_pick]})
+            starttimes.append(starttime)
     # Cut the data
     st1 = Stream()
     for _starttime in starttimes:
@@ -656,11 +667,11 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                msg = ('Pick for ' + pick.waveform_id.station_code + '.' +
-                       pick.waveform_id.channel_code + ' has no phase ' +
-                       'hint given, you should not use this template for ' +
-                       'cross-correlation re-picking!')
-                warnings.warn(msg)
+                debug_print("Pick for {0}.{1} has no phase hint given, you "
+                            "should not use this template for cross-correlation"
+                            " re-picking!".format(
+                    pick.waveform_id.station_code,
+                    pick.waveform_id.channel_code), 2, debug)
             starttime = pick.time - prepick
             debug_print(
                 "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,
@@ -691,10 +702,7 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
             debug_print('No pick for ' + tr.stats.station + '.' +
                         tr.stats.channel, 0, debug)
     if plot:
-        background = stplot.trim(
-            st1.sort(['starttime'])[0].stats.starttime - 10,
-            st1.sort(['starttime'])[-1].stats.endtime + 10)
-        tplot(st1, background=background, picks=picks_copy,
+        tplot(st1, background=stplot, picks=picks_copy,
               title='Template for ' + str(st1[0].stats.starttime))
         del stplot
     return st1

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -42,6 +42,7 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
+import warnings
 import copy
 import os
 
@@ -686,12 +687,12 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                debug_print(
+                warnings.warn(
                     "Pick for {0}.{1} has no phase hint given, you should not "
                     "use this template for cross-correlation"
                     " re-picking!".format(
                         pick.waveform_id.station_code,
-                        pick.waveform_id.channel_code), 2, debug)
+                        pick.waveform_id.channel_code))
             starttime = pick.time - prepick
             debug_print(
                 "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -43,6 +43,7 @@ from __future__ import unicode_literals
 
 import numpy as np
 import copy
+import os
 
 from obspy import Stream, read, Trace, UTCDateTime, read_events
 from obspy.core.event import Catalog
@@ -76,7 +77,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                  length, prepick, swin, process_len=86400,
                  all_horiz=False, delayed=True, plot=False, debug=0,
                  return_event=False, min_snr=None, parallel=False,
-                 **kwargs):
+                 save_progress=False, **kwargs):
     """
     Generate processed and cut waveforms for use as templates.
 
@@ -123,6 +124,10 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         the whole window given.
     :type parallel: bool
     :param parallel: Whether to process data in parallel or not.
+    :type save_progress: bool
+    :param save_progress: 
+        Whether to save the resulting party at every data step or not.
+        Useful for long-running processes.
 
     :returns: List of :class:`obspy.core.stream.Stream` Templates
     :rtype: list
@@ -338,6 +343,13 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                 min_snr=min_snr)
             process_lengths.append(len(st[0].data) / samp_rate)
             temp_list.append(template)
+        if save_progress:
+            if not os.path.isdir("eqcorrscan_temporary_templates"):
+                os.path.makedirs("eqcorrscan_temporary_templates")
+            for template in temp_list:
+                template.write(
+                    "eqcorrscan_temporary_templates{0}{1}.ms".format(
+                        os.path.sep, template[0].stats.starttime))
         del st
     if return_event:
         return temp_list, catalog, process_lengths

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -263,6 +263,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         all_channels = False
     for sub_catalog in sub_catalogs:
         if method in ['from_seishub', 'from_client']:
+            debug_print("Downloading data", 1, debug)
             st = _download_from_client(
                 client=client, client_type=client_map[method],
                 catalog=sub_catalog, data_pad=data_pad,
@@ -573,7 +574,7 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 "{0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
-        if not pick.waveform_id.station_code or pick.waveform_id.channel_code:
+        if not pick.waveform_id.station_code or not pick.waveform_id.channel_code:
             debug_print(
                 "Pick not associated with a channel, will not use it:"
                 " {0}".format(pick), 1, debug)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -441,8 +441,9 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     for event in catalog:
         for pick in event.picks:
             if not pick.waveform_id:
-                print('Pick not associated with waveforms, will not use.')
-                print(pick)
+                debug_print(
+                    "Pick not associated with waveforms, will not use:"
+                    " {0}".format(pick), 1, debug)
                 continue
             if all_channels:
                 channel_code = pick.waveform_id.channel_code[0:2] + "?"
@@ -567,18 +568,15 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         assert _swin in ['P', 'all', 'S', 'P_all', 'S_all']
     for pick in picks_copy:
         if not pick.waveform_id:
-            print('Pick not associated with waveform, will not use it.')
-            print(pick)
+            debug_print(
+                "Pick not associated with waveform, will not use it: "
+                "{0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
-        if not pick.waveform_id.station_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
-            picks_copy.remove(pick)
-            continue
-        if not pick.waveform_id.channel_code:
-            print('Pick not associated with a station, will not use it.')
-            print(pick)
+        if not pick.waveform_id.station_code or pick.waveform_id.channel_code:
+            debug_print(
+                "Pick not associated with a channel, will not use it:"
+                " {0}".format(pick), 1, debug)
             picks_copy.remove(pick)
             continue
     for tr in st:
@@ -681,8 +679,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 starttime=starttime, endtime=starttime + length,
                 nearest_sample=False).copy()
             if len(tr_cut.data) == 0:
-                print('No data provided for %s.%s starting at %s' %
-                      (tr.stats.station, tr.stats.channel, str(starttime)))
+                debug_print(
+                    "No data provided for {0}.{1} starting at {2}".format(
+                        tr.stats.station, tr.stats.channel, starttime), 3,
+                    debug)
                 continue
             # Ensure that the template is the correct length
             if len(tr_cut.data) == (tr_cut.stats.sampling_rate *
@@ -694,8 +694,9 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 debug)
             if min_snr is not None and \
                max(tr_cut.data) / noise_amp < min_snr:
-                print('Signal-to-noise ratio below threshold for %s.%s' %
-                      (tr_cut.stats.station, tr_cut.stats.channel))
+                debug_print(
+                    "Signal-to-noise ratio below threshold for {0}.{1}".format(
+                        tr_cut.stats.station, tr_cut.stats.channel), 3, debug)
                 continue
             st1 += tr_cut
             used_tr = True

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -667,11 +667,12 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         used_tr = False
         for pick in _starttime['picks']:
             if not pick.phase_hint:
-                debug_print("Pick for {0}.{1} has no phase hint given, you "
-                            "should not use this template for cross-correlation"
-                            " re-picking!".format(
-                    pick.waveform_id.station_code,
-                    pick.waveform_id.channel_code), 2, debug)
+                debug_print(
+                    "Pick for {0}.{1} has no phase hint given, you should not "
+                    "use this template for cross-correlation"
+                    " re-picking!".format(
+                        pick.waveform_id.station_code,
+                        pick.waveform_id.channel_code), 2, debug)
             starttime = pick.time - prepick
             debug_print(
                 "Cutting " + tr.stats.station + '.' + tr.stats.channel, 0,

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -640,6 +640,18 @@ class TestMatchObjects(unittest.TestCase):
                             det.__dict__[key], check_det.__dict__[key], 6)
             # self.assertEqual(fam.template, check_fam.template)
 
+    def test_tribe_detect_save_progress(self):
+        """Test the detect method on Tribe objects"""
+        party = self.tribe.detect(
+            stream=self.unproc_st, threshold=8.0, threshold_type='MAD',
+            trig_int=6.0, daylong=False, plotvar=False, parallel_process=False,
+            save_progress=True)
+        self.assertEqual(len(party), 4)
+        self.assertTrue(os.path.isfile("eqcorrscan_temporary_party.tgz"))
+        saved_party = Party().read("eqcorrscan_temporary_party.tgz")
+        self.assertEqual(party, saved_party)
+        os.remove("eqcorrscan_temporary_party.tgz")
+
     def test_tribe_detect_masked_data(self):
         """Test using masked data - possibly raises error at pre-processing.
         Padding may also result in error at correlation stage due to poor
@@ -691,6 +703,19 @@ class TestMatchObjects(unittest.TestCase):
             threshold=8.0, threshold_type='MAD', trig_int=6.0,
             daylong=False, plotvar=False)
         self.assertEqual(len(party), 4)
+
+    @pytest.mark.flaky(reruns=2)
+    def test_client_detect_save_progress(self):
+        """Test the client_detect method."""
+        client = Client('NCEDC')
+        party = self.tribe.copy().client_detect(
+            client=client, starttime=self.t1, endtime=self.t2,
+            threshold=8.0, threshold_type='MAD', trig_int=6.0,
+            daylong=False, plotvar=False, save_progress=True)
+        self.assertTrue(os.path.isfile("eqcorrscan_temporary_party.tgz"))
+        saved_party = Party().read("eqcorrscan_temporary_party.tgz")
+        self.assertEqual(party, saved_party)
+        os.remove("eqcorrscan_temporary_party.tgz")
 
     def test_party_io(self):
         """Test reading and writing party objects."""

--- a/eqcorrscan/tests/template_gen_test.py
+++ b/eqcorrscan/tests/template_gen_test.py
@@ -278,8 +278,7 @@ class TestTemplateGeneration(unittest.TestCase):
            (86400, [5, 60, 300])]:
             for data_pad in pads:
                 sub_catalogs = _group_events(
-                    catalog=catalog, process_len=process_len,
-                    data_pad=data_pad)
+                    catalog=catalog, process_len=process_len)
                 k_events = 0
                 for sub_catalog in sub_catalogs:
                     min_time = min([event.origins[0].time

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -14,13 +14,8 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import logging
 
-LOG = {0: logging.debug, 1: logging.info, 2: logging.warning, 3: logging.error,
-       4: logging.critical}
-
-
-def debug_print(string, debug_level, print_level, use_logging=True):
+def debug_print(string, debug_level, print_level):
     """
     Print the string if the print_level exceeds the debug_level.
 
@@ -30,21 +25,14 @@ def debug_print(string, debug_level, print_level, use_logging=True):
     :param print_level: Print-level for statement
     :type debug_level: int
     :param debug_level: Output level for function
-    :type use_logging: bool
-    :param use_logging: Uses logging to output information
 
     .. rubric:: Example
-    >>> debug_print("Albert", 2, 0, use_logging=False)
-    >>> debug_print("Norman", 0, 2, use_logging=False)
+    >>> debug_print("Albert", 2, 0)
+    >>> debug_print("Norman", 0, 2)
     Norman
     """
-    if not use_logging and print_level > debug_level:
+    if print_level > debug_level:
         print(string)
-    if use_logging:
-        try:
-            LOG[debug_level](string)
-        except IndexError:
-            LOG[4](string)
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -14,8 +14,13 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import logging
 
-def debug_print(string, debug_level, print_level):
+LOG = {0: logging.debug, 1: logging.info, 2: logging.warning, 3: logging.error,
+       4: logging.critical}
+
+
+def debug_print(string, debug_level, print_level, use_logging=True):
     """
     Print the string if the print_level exceeds the debug_level.
 
@@ -25,14 +30,21 @@ def debug_print(string, debug_level, print_level):
     :param print_level: Print-level for statement
     :type debug_level: int
     :param debug_level: Output level for function
+    :type use_logging: bool
+    :param use_logging: Uses logging to output information
 
     .. rubric:: Example
-    >>> debug_print("Albert", 2, 0)
-    >>> debug_print("Norman", 0, 2)
+    >>> debug_print("Albert", 2, 0, use_logging=False)
+    >>> debug_print("Norman", 0, 2, use_logging=False)
     Norman
     """
-    if print_level > debug_level:
+    if not use_logging and print_level > debug_level:
         print(string)
+    if use_logging:
+        try:
+            LOG[print_level](string)
+        except IndexError:
+            LOG[4](string)
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/utils/debug_log.py
+++ b/eqcorrscan/utils/debug_log.py
@@ -42,7 +42,7 @@ def debug_print(string, debug_level, print_level, use_logging=True):
         print(string)
     if use_logging:
         try:
-            LOG[print_level](string)
+            LOG[debug_level](string)
         except IndexError:
             LOG[4](string)
 

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -434,13 +434,11 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
                     ' are not of daylong length, will zero pad', 2, debug)
         if tr.stats.endtime - tr.stats.starttime < 0.8 * length\
            and not ignore_length:
-            debug_print(
+            raise NotImplementedError(
                 "Data for {0}.{1} is {2} hours long, which is less than 80 "
                 "percent of the desired length, will not pad".format(
                     tr.stats.station, tr.stats.channel,
-                    (tr.stats.endtime - tr.stats.starttime) / 3600), 4, debug)
-            tr.data = np.ndarray(0)
-            return tr
+                    (tr.stats.endtime - tr.stats.starttime) / 3600))
         # trim, then calculate length of any pads required
         tr = tr.trim(starttime, starttime + length, nearest_sample=True)
         pre_pad_secs = tr.stats.starttime - starttime

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -16,7 +16,6 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 import numpy as np
-import warnings
 import datetime as dt
 
 from multiprocessing import Pool, cpu_count
@@ -305,9 +304,10 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 # If the trace starts within 1 sample of the next day, use the
                 # next day as the startdate
                 startdates.append((tr.stats.starttime + 86400).date)
-                warnings.warn('%s starts within 1 sample of the next day, '
-                              'using this time %s' %
-                              (tr.id, (tr.stats.starttime + 86400).date))
+                debug_print(
+                    '{0} starts within 1 sample of the next day, using this '
+                    'time {1}'.format(tr.id, (tr.stats.starttime + 86400).date),
+                    2, debug)
             else:
                 startdates.append(tr.stats.starttime.date)
         # Check that all traces start on the same date...
@@ -481,15 +481,15 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
         tr.data = highpass(tr.data, lowcut, tr.stats.sampling_rate,
                            filt_order, True)
     else:
-        warnings.warn('No filters applied')
+        debug_print('No filters applied', 2, debug)
     # Account for two letter channel names in s-files and therefore templates
     if seisan_chan_names:
         tr.stats.channel = tr.stats.channel[0] + tr.stats.channel[-1]
 
     # Sanity check the time header
     if tr.stats.starttime.day != day and clip:
-        warnings.warn("Time headers do not match expected date: " +
-                      str(tr.stats.starttime))
+        debug_print("Time headers do not match expected date: {0}".format(
+            tr.stats.starttime), 2, debug)
 
     if padded:
         debug_print("Reapplying zero pads post processing", 1, debug)

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -306,8 +306,8 @@ def dayproc(st, lowcut, highcut, filt_order, samp_rate, starttime, debug=0,
                 startdates.append((tr.stats.starttime + 86400).date)
                 debug_print(
                     '{0} starts within 1 sample of the next day, using this '
-                    'time {1}'.format(tr.id, (tr.stats.starttime + 86400).date),
-                    2, debug)
+                    'time {1}'.format(
+                        tr.id, (tr.stats.starttime + 86400).date), 2, debug)
             else:
                 startdates.append(tr.stats.starttime.date)
         # Check that all traces start on the same date...

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -529,7 +529,7 @@ def process(tr, lowcut, highcut, filt_order, samp_rate, debug,
     # Final visual check for debug
     if debug > 4:
         tr.plot()
-    return tr, True
+    return tr
 
 
 def _zero_pad_gaps(tr, gaps, fill_gaps=True):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy>=1.12
 matplotlib>=1.3.0
 scipy>=0.18
-LatLon
 bottleneck
 obspy>=1.0.3
 h5py

--- a/setup.py
+++ b/setup.py
@@ -315,12 +315,11 @@ def setup_package():
         build_requires = ['numpy>=1.6, <2.0']
 
     if not READ_THE_DOCS:
-        install_requires = ['matplotlib>=1.3.0', 'scipy>=0.18', 'LatLon',
+        install_requires = ['matplotlib>=1.3.0', 'scipy>=0.18',
                             'bottleneck', 'obspy>=1.0.3', 'numpy>=1.12',
                             'h5py']
     else:
-        install_requires = ['matplotlib>=1.3.0', 'LatLon', 'obspy>=1.0.3',
-                            'mock']
+        install_requires = ['matplotlib>=1.3.0', 'obspy>=1.0.3', 'mock']
     install_requires.extend(build_requires)
 
     setup_args = {


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Patches a few `from_client` methods that were annoying.

1. Do not error when downloaded data are not long enough, just don't use them;
2. Allow multiple `swin` arguments so that both P and S phase templates can be created in one go;
3. Add ability to save progress on long-running methods (needs checking).

### Why was it initiated?  Any relevant Issues?

Downloading data when a station went offline caused an error. This is fine if you have the data locally, but if it's coming from a client you can't do anything about it. So, now if data downloaded would result in an error, those channels are dropped and the user is warned.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `develop` for bug fixes.
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
