### PR TITLE
Use data-pad when grouping events

### DIFF
--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -228,7 +228,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         data_pad = kwargs.get('data_pad', 90)
         # Group catalog into days and only download the data once per day
         sub_catalogs = _group_events(
-            catalog=catalog, process_len=process_len)
+            catalog=catalog, process_len=process_len, template_length=length,
+            data_pad=data_pad)
         if method == 'from_client':
             client = FDSNClient(kwargs.get('client_id', None))
             available_stations = []
@@ -733,7 +734,7 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     return st1
 
 
-def _group_events(catalog, process_len):
+def _group_events(catalog, process_len, template_length, data_pad):
     """
     Internal function to group events into sub-catalogs based on process_len.
 
@@ -756,7 +757,11 @@ def _group_events(catalog, process_len):
     sub_catalog = Catalog([catalog[0]])
     for event in catalog[1:]:
         origin_time = (event.preferred_origin() or event.origins[0]).time
-        if origin_time - sub_catalog[0].origins[0].time < process_len:
+        last_pick = sorted(event.picks, key=lambda p: p.time)[-1]
+        max_diff = (
+            process_len - (last_pick.time - origin_time) - template_length)
+        max_diff -= 2 * data_pad
+        if origin_time - sub_catalog[0].origins[0].time < max_diff:
             sub_catalog.append(event)
         else:
             sub_catalogs.append(sub_catalog)

--- a/eqcorrscan/tests/template_gen_test.py
+++ b/eqcorrscan/tests/template_gen_test.py
@@ -278,7 +278,7 @@ class TestTemplateGeneration(unittest.TestCase):
            (86400, [5, 60, 300])]:
             for data_pad in pads:
                 sub_catalogs = _group_events(
-                    catalog=catalog, process_len=process_len, 
+                    catalog=catalog, process_len=process_len,
                     template_length=10, data_pad=data_pad)
                 k_events = 0
                 for sub_catalog in sub_catalogs:

--- a/eqcorrscan/tests/template_gen_test.py
+++ b/eqcorrscan/tests/template_gen_test.py
@@ -278,7 +278,8 @@ class TestTemplateGeneration(unittest.TestCase):
            (86400, [5, 60, 300])]:
             for data_pad in pads:
                 sub_catalogs = _group_events(
-                    catalog=catalog, process_len=process_len)
+                    catalog=catalog, process_len=process_len, 
+                    template_length=10, data_pad=data_pad)
                 k_events = 0
                 for sub_catalog in sub_catalogs:
                     min_time = min([event.origins[0].time


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Adds back in the data-pad option for catalog grouping.

### Why was it initiated?  Any relevant Issues?

Data downloaded did not encompass events.

### PR Checklist
- [x] Correct base branch selected? `master` for new features, `develop` for bug fixes.
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
~~- [ ] Any new features or fixed regressions are be covered via new tests.~~
~~- [ ] Any new or changed features have are fully documented.~~
~~- [ ] Significant changes have been added to `CHANGES.md`.~~
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
