### PR TITLE
Download handling in Tribe.client_detect

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
   should no-longer happen.
 * Add `select` method to `Party` and `Tribe` to allow selection of a 
   specific family/template.
+* Add ability to "retry" downloading in `Tribe.client_detect`.
 
 ## 0.3.1
 * Cleaned imports in utils modules


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Adds a `retires` argument to `Tribe.client_detect` which provides a means of trying downloading of data - will fail if this fails multiple times.

### Why was it initiated?  Any relevant Issues?

Servers do not always provide the data, and networks time-out etc. This copes with that.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
