### PR TITLE
Assertion that correlation sum less than the number of channels

### DIFF
--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -3003,6 +3003,8 @@ class Detection(object):
                        detect_time.strftime('%Y%m%d_%H%M%S%f'))
         if event is not None:
             event.resource_id = self.id
+        if self.typeofdet == 'corr':
+            assert abs(self.detect_val) <= self.no_chans
 
     def __repr__(self):
         """Simple print."""

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1168,7 +1168,7 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                     assert (
                         abs(det.__dict__[key] -
                             check_det.__dict__[key]) < 0.00001)
-                elif key == 'template_name':
+                elif key in ['template_name', 'id']:
                     continue
                     # Name relies on creation-time, which is checked elsewhere,
                     # ignore it.

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -33,10 +33,9 @@ class TestCoreMethods(unittest.TestCase):
     Tests for internal _template_loop and normxcorr2 functions.
     """
     def test_detection_assertion(self):
-        with self.asserts(AssertionError):
-            detection = Detection(
-                typeofdet="corr", no_chans=3, detect_val=20)
-        
+        with self.assertRaises(AssertionError):
+            Detection(typeofdet="corr", no_chans=3, detect_val=20)
+
     def test_perfect_normxcorr2(self):
         """
         Simple test of normxcorr2 to ensure data are detected

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -32,6 +32,11 @@ class TestCoreMethods(unittest.TestCase):
     """
     Tests for internal _template_loop and normxcorr2 functions.
     """
+    def test_detection_assertion(self):
+        with self.asserts(AssertionError):
+            detection = Detection(
+                typeofdet="corr", no_chans=3, detect_val=20)
+        
     def test_perfect_normxcorr2(self):
         """
         Simple test of normxcorr2 to ensure data are detected

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -34,7 +34,10 @@ class TestCoreMethods(unittest.TestCase):
     """
     def test_detection_assertion(self):
         with self.assertRaises(AssertionError):
-            Detection(typeofdet="corr", no_chans=3, detect_val=20)
+            Detection(
+                template_name='a', detect_time=UTCDateTime(), threshold=1.2,
+                threshold_input=8.0, threshold_type="MAD", typeofdet="corr",
+                no_chans=3, detect_val=20)
 
     def test_perfect_normxcorr2(self):
         """

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1153,7 +1153,7 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                         print(key)
                     assert np.allclose(
                         det.__dict__[key], check_det.__dict__[key],
-                        atol=0.01)
+                        atol=float_tol)
                 elif isinstance(det.__dict__[key], np.float32):
                     if not np.allclose(
                             det.__dict__[key], check_det.__dict__[key],
@@ -1161,7 +1161,7 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                         print(key)
                     assert np.allclose(
                         det.__dict__[key], check_det.__dict__[key],
-                        atol=0.01)
+                        atol=float_tol)
                 elif isinstance(det.__dict__[key], UTCDateTime):
                     if not det.__dict__[key] == check_det.__dict__[key]:
                         print(key)


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Adds and assertion to `Detection.__init__` that if the type of detection is `"corr"` then the correlation sum must be less than or equal to the number of channels.

### Why was it initiated?  Any relevant Issues?

The fails in #248 were associated with over-estimating the correlation sum - I still haven't worked this out, and can't replicate on my machine, but this will at least fail things closer to the source.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
