### PR TITLE
Do not force day cuts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,6 +26,8 @@
 * Add `select` method to `Party` and `Tribe` to allow selection of a 
   specific family/template.
 * Add ability to "retry" downloading in `Tribe.client_detect`.
+* Allow users to pass data of day-long length that is *not* cut at the start
+  of a day.
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -26,8 +26,10 @@
 * Add `select` method to `Party` and `Tribe` to allow selection of a 
   specific family/template.
 * Add ability to "retry" downloading in `Tribe.client_detect`.
-* Allow users to pass data of day-long length that is *not* cut at the start
-  of a day.
+* Change behaviour of template_gen for data that are daylong, but do not start
+  within 1 minute of a day-break - previous versions enforced padding to
+  start and end at day-breaks, which led to zeros in the data and undesirable 
+  behaviour.
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -78,7 +78,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                  length, prepick, swin, process_len=86400,
                  all_horiz=False, delayed=True, plot=False, debug=0,
                  return_event=False, min_snr=None, parallel=False,
-                 num_cores=False, save_progress=False, **kwargs):
+                 num_cores=False, save_progress=False, daylong=None,
+                 **kwargs):
     """
     Generate processed and cut waveforms for use as templates.
 
@@ -134,6 +135,13 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     :param save_progress:
         Whether to save the resulting party at every data step or not.
         Useful for long-running processes.
+    :type daylong: bool
+    :param daylong:
+        Whether data should be processed as daylong starting at the start of a
+        day or not.  If not set, this will check whether data are close to
+        day-long and process them as if they are.  Note that this will trim the
+        data at day-breaks, set to False if you do not provide data split at
+        day-breaks!
 
     :returns: List of :class:`obspy.core.stream.Stream` Templates
     :rtype: list
@@ -286,7 +294,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         if process:
             data_len = max([len(tr.data) / tr.stats.sampling_rate
                             for tr in st])
-            if 80000 < data_len < 90000:
+            if daylong is None and 80000 < data_len < 90000:
                 daylong = True
             else:
                 daylong = False


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Changes the behaviour of `template_gen` (and therefore `Tribe.construct`) for data that are day-long length, but do not start at the start of a day.  Previously data that started at say 5pm, were padded to start at midnight (17 hours before), and trimmed at the end of the day.  I'm fairly sure this isn't what anyone would want.

Now the data are checked to work out if the data actually do start near a day-break and then uses dayproc, otherwise it uses shortproc, which is a touch slower, but doesn't enforce as much.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
  - [ ] Test for day-long data that do not start at day-break - test should check that templates that are in the next day are made (they weren't in the old version because data were trimmed at the end of day).
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
