### PR TITLE
pin numpy to v.1.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
         PYFLAKES="pyflakes=0.9.0"
       fi
   - echo $PYTHON_VERSION
-  - conda create -q -n test-environment python=$PYTHON_VERSION colorama numpy scipy matplotlib obspy flake8 mock coverage bottleneck pyproj
+  - conda create -q -n test-environment python=$PYTHON_VERSION colorama numpy=1.14 scipy matplotlib obspy flake8 mock coverage bottleneck pyproj
   - source activate test-environment
   - conda install h5py
   - if [ "$MKL" == "1" ]; then conda install -q mkl mkl-include; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ install:
   #      else
   #        PYFLAKES="pyflakes=0.9.0"
   #      fi
-  - "conda install -q --yes pip obspy numpy>=1.12.0 scipy>=0.18 matplotlib mock flake8 pyflakes cython h5py pyproj bottleneck lxml"
+  - "conda install -q --yes pip obspy numpy=1.14 scipy>=0.18 matplotlib mock flake8 pyflakes cython h5py pyproj bottleneck lxml"
   # additional dependecies
   - "pip install pyimgur"
 


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Pins numpy to version 1.14 for travis and appveyor testing - it looks like 1.15.0 isn't working from conda at the moment for us for [Python < 3.6](https://travis-ci.org/eqcorrscan/EQcorrscan/jobs/409690060).

Note that if this works, then an issue should be raised at numpy, and, once fixed, this pin should be removed.

If it doesn't fix the tests, then who knows?