### PR TITLE
Patch process-len gaps for client_detect

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
-      brew update;
+#      brew update;
       brew install gcc6;
       export CC=gcc-6;
       export CXX=g++-6;
-      brew install fftw;
-      brew list;
+#      brew install fftw;
+#      brew list;
     else
       export OS="Linux";
       export py=$PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
       env: PYTHON_VERSION=3.6 MKL=0
     - os: linux
       env: PYTHON_VERSION=3.6 MKL=1
-
     - os: osx
       osx_image: xcode8
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ addons:
 
 matrix:
   include:
-#    - os: linux
-#      env: PYTHON_VERSION=2.7 MKL=0
-#    - os: linux
-#      env: PYTHON_VERSION=3.5 MKL=0
-#    - os: linux
-#      env: PYTHON_VERSION=3.6 MKL=0
-#    - os: linux
-#      env: PYTHON_VERSION=3.6 MKL=1
+    - os: linux
+      env: PYTHON_VERSION=2.7 MKL=0
+    - os: linux
+      env: PYTHON_VERSION=3.5 MKL=0
+    - os: linux
+      env: PYTHON_VERSION=3.6 MKL=0
+    - os: linux
+      env: PYTHON_VERSION=3.6 MKL=1
 
     - os: osx
       osx_image: xcode8
@@ -24,14 +24,6 @@ matrix:
 sudo: false
 
 install:
-#      brew update;
-#      brew install libomp;
-#      brew install gcc6;
-#      export CC=gcc-6;
-#      export CXX=g++-6;
-#      brew install fftw;
-#      brew list;
-# Remove homebrew to avoid conflicts
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
@@ -71,11 +63,11 @@ install:
 
 script:
    - export MPLBACKEND=Agg
-#   - py.test --runslow -m "not serial and not network" -n 2
+   - py.test --runslow -m "not serial and not network" -n 2
    - export OMP_NUM_THREADS=2;
    # These tests use multi-threading
    - py.test -m "serial and not network" --cov-append
-#   - py.test --runsuperslow -s eqcorrscan/tests/tutorials_test.py --cov-append
+   - py.test --runsuperslow -s eqcorrscan/tests/tutorials_test.py --cov-append
 
 after_success:
   # Check how much code is actually tested and send this report to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,17 +52,14 @@ install:
   - conda config --add channels conda-forge
   - conda update -q conda
   - conda info -a
-  - |
-      if [[ "${py:0:1}" == "3" ]]; then
-        PYFLAKES="pyflakes=1.0.0"
-      else
-        PYFLAKES="pyflakes=0.9.0"
-      fi
   - echo $PYTHON_VERSION
   - conda create -q -n test-environment python=$PYTHON_VERSION colorama numpy=1.14 scipy matplotlib obspy flake8 mock coverage bottleneck pyproj
   - source activate test-environment
   - conda install h5py
   - if [ "$MKL" == "1" ]; then conda install -q mkl mkl-include; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      conda install clangdev=4 openmp=4 libcxx=4;
+    fi
   - pip install pep8-naming pytest pytest-cov pytest-pep8 pytest-xdist pytest-rerunfailures pytest-mpl codecov Cython
   - pip freeze
   - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,7 @@ install:
   - conda install h5py
   - if [ "$MKL" == "1" ]; then conda install -q mkl mkl-include; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda install clangdev=4 openmp=4 libcxx=4;
+      conda install clangdev=4 openmp=4 libcxx=4 toolchain toolchain_c_osx-64;
     fi
   - pip install pep8-naming pytest pytest-cov pytest-pep8 pytest-xdist pytest-rerunfailures pytest-mpl codecov Cython
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,9 +31,14 @@ install:
 #      export CXX=g++-6;
 #      brew install fftw;
 #      brew list;
+# Remove homebrew to avoid conflicts
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew;
+      chmod +x ~/uninstall_homebrew;
+      ~/uninstall_homebrew -fq;
+      rm ~/uninstall_homebrew;
     else
       export OS="Linux";
       export py=$PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
     - os: osx
       osx_image: xcode8
       env:
-        - PYTHON_VERSION=3.5 MKL=0
+        - PYTHON_VERSION=3.5 MKL=1
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,14 +7,14 @@ addons:
 
 matrix:
   include:
-    - os: linux
-      env: PYTHON_VERSION=2.7 MKL=0
-    - os: linux
-      env: PYTHON_VERSION=3.5 MKL=0
-    - os: linux
-      env: PYTHON_VERSION=3.6 MKL=0
-    - os: linux
-      env: PYTHON_VERSION=3.6 MKL=1
+#    - os: linux
+#      env: PYTHON_VERSION=2.7 MKL=0
+#    - os: linux
+#      env: PYTHON_VERSION=3.5 MKL=0
+#    - os: linux
+#      env: PYTHON_VERSION=3.6 MKL=0
+#    - os: linux
+#      env: PYTHON_VERSION=3.6 MKL=1
 
     - os: osx
       osx_image: xcode8
@@ -72,12 +72,11 @@ install:
 
 script:
    - export MPLBACKEND=Agg
-   - py.test --runslow -m "not serial and not network" -n 2
+#   - py.test --runslow -m "not serial and not network" -n 2
    - export OMP_NUM_THREADS=2;
    # These tests use multi-threading
    - py.test -m "serial and not network" --cov-append
-   - py.test --runsuperslow -s eqcorrscan/tests/tutorials_test.py --cov-append
-#   - py.test -m "network" --cov-append -n 2
+#   - py.test --runsuperslow -s eqcorrscan/tests/tutorials_test.py --cov-append
 
 after_success:
   # Check how much code is actually tested and send this report to codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,10 +35,6 @@ install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
-      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew;
-      chmod +x ~/uninstall_homebrew;
-      ~/uninstall_homebrew -fq;
-      rm ~/uninstall_homebrew;
     else
       export OS="Linux";
       export py=$PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,10 @@ install:
       export OS="MacOSX";
       export py=$PYTHON_VERSION;
 #      brew update;
-      brew install gcc6;
-      export CC=gcc-6;
-      export CXX=g++-6;
+#      brew install libomp;
+#      brew install gcc6;
+#      export CC=gcc-6;
+#      export CXX=g++-6;
 #      brew install fftw;
 #      brew list;
     else

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,6 @@ matrix:
 sudo: false
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      export OS="MacOSX";
-      export py=$PYTHON_VERSION;
 #      brew update;
 #      brew install libomp;
 #      brew install gcc6;
@@ -34,6 +31,9 @@ install:
 #      export CXX=g++-6;
 #      brew install fftw;
 #      brew list;
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      export OS="MacOSX";
+      export py=$PYTHON_VERSION;
     else
       export OS="Linux";
       export py=$PYTHON_VERSION;

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,15 +37,13 @@ install:
       export OS="Linux";
       export py=$PYTHON_VERSION;
     fi
-  - if [[ "$py" == "2.7_with_system_site_packages" ]]; then
-      export py="2.7";
-    fi
   - if [[ "${py:0:1}" == '2' ]]; then
       wget https://repo.continuum.io/miniconda/Miniconda2-latest-${OS}-x86_64.sh -O miniconda.sh;
     else
       wget https://repo.continuum.io/miniconda/Miniconda3-latest-${OS}-x86_64.sh -O miniconda.sh;
     fi
   - export OMP_NUM_THREADS=1;
+  # Enforce single-threaded just to stay in memory
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"
   - hash -r
@@ -75,6 +73,8 @@ install:
 script:
    - export MPLBACKEND=Agg
    - py.test --runslow -m "not serial and not network" -n 2
+   - export OMP_NUM_THREADS=2;
+   # These tests use multi-threading
    - py.test -m "serial and not network" --cov-append
    - py.test --runsuperslow -s eqcorrscan/tests/tutorials_test.py --cov-append
 #   - py.test -m "network" --cov-append -n 2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,9 @@
   did cause issues for on Linux for Python 2.7 and Mac OS builds.
 * KeyboardInterrupt (e.g. ctrl-c) should now be caught during python parallel
   processes.
+* Stopped allowing outer-threading on OSX, clang openMP is not thread-safe
+  for how we have this set-up. Inner threading is faster and more memory
+  efficient anyway.
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -48,6 +48,10 @@
   in resulting correlations (~0.07 per channel).
   * Includes extra stability check in fftw_normxcorr which affects the
     last sample before a gap when that sample is near-zero.
+* BUG-FIX: fftw correlation dot product was not thread-safe on some systems.
+  The dot-product did not have the inner index protected as a private variable.
+  This did not appear to cause issues for Linux with Python 3.x or Windows, but
+  did cause issues for on Linux for Python 2.7 and Mac OS builds.
 * KeyboardInterrupt (e.g. ctrl-c) should now be caught during python parallel
   processes.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -46,6 +46,8 @@
   one sample too long resulting in minor differences in data processing
   (due to difference in FFT length) and therefore minor differences 
   in resulting correlations (~0.07 per channel).
+  * Includes extra stability check in fftw_normxcorr which affects the
+    last sample before a gap when that sample is near-zero.
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -39,6 +39,13 @@
     `show`, `return_figure` and `title`.
   * All plotting functions return a figure.
   * `SVD_plot` renamed to `svd_plot`
+* Enforce pre-processing even when no filters or resampling is to be done
+  to ensure gaps are properly processed (when called from `Tribe.detect`,
+  `Template.detect` or `Tribe.client_detect`)
+* BUG-FIX in `Tribe.client_detect` where data were processed from data 
+  one sample too long resulting in minor differences in data processing
+  (due to difference in FFT length) and therefore minor differences 
+  in resulting correlations (~0.07 per channel).
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -244,8 +244,10 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
     elif method == 'from_meta_file':
         if isinstance(kwargs.get('meta_file'), Catalog):
             catalog = kwargs.get('meta_file')
-        else:
+        elif kwargs.get('meta_file'):
             catalog = read_events(kwargs.get('meta_file'))
+        elif kwargs.get('catalog'):
+            catalog = kwargs.get('catalog')
         sub_catalogs = [catalog]
         st = kwargs.get('st', Stream())
         process = kwargs.get('process', True)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -479,7 +479,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
                 channel_code, pick.waveform_id.location_code))
     starttime = UTCDateTime(
         catalog[0].origins[0].time - data_pad)
-    endtime = starttime + process_len
+    endtime = starttime + process_len + data_pad
     # Check that endtime is after the last event
     if not endtime > catalog[-1].origins[0].time + data_pad:
         raise TemplateGenError(
@@ -508,7 +508,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     # the desired length
     final_channels = []
     for tr in st:
-        tr.trim(starttime, endtime)
+        tr.trim(starttime + data_pad, endtime - data_pad)
         if len(tr.data) == (process_len * tr.stats.sampling_rate) + 1:
             tr.data = tr.data[1:len(tr.data)]
         if tr.stats.endtime - tr.stats.starttime < 0.8 * process_len:

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -479,7 +479,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
                 channel_code, pick.waveform_id.location_code))
     starttime = UTCDateTime(
         catalog[0].origins[0].time - data_pad)
-    endtime = starttime + process_len + data_pad
+    endtime = starttime + process_len
     # Check that endtime is after the last event
     if not endtime > catalog[-1].origins[0].time + data_pad:
         raise TemplateGenError(
@@ -508,7 +508,7 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
     # the desired length
     final_channels = []
     for tr in st:
-        tr.trim(starttime + data_pad, endtime - data_pad)
+        tr.trim(starttime, endtime)
         if len(tr.data) == (process_len * tr.stats.sampling_rate) + 1:
             tr.data = tr.data[1:len(tr.data)]
         if tr.stats.endtime - tr.stats.starttime < 0.8 * process_len:

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -240,6 +240,10 @@ def stream_cc_output_dict(multichannel_templates, multichannel_stream):
     for name, func in stream_funcs.items():
         for cores in [1, cpu_count()]:
             print("Running {0} with {1} cores".format(name, cores))
+
+            cc_out = time_func(func, name, multichannel_templates,
+                               multichannel_stream, cores=cores)
+            out["{0}.{1}".format(name, cores)] = cc_out
             if "fftw" in name:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
@@ -248,9 +252,6 @@ def stream_cc_output_dict(multichannel_templates, multichannel_stream):
                     func, name, multichannel_templates, multichannel_stream,
                     cores=1, cores_outer=cores)
                 out["{0}.{1}_outer".format(name, cores)] = cc_out
-            cc_out = time_func(func, name, multichannel_templates,
-                               multichannel_stream, cores=cores)
-            out["{0}.{1}".format(name, cores)] = cc_out
     return out
 
 
@@ -270,6 +271,10 @@ def gappy_stream_cc_output_dict(
         for cores in [1, cpu_count()]:
             # Check for same result both single and multi-threaded
             print("Running {0} with {1} cores".format(name, cores))
+            with warnings.catch_warnings(record=True) as w:
+                cc_out = time_func(func, name, multichannel_templates,
+                                   gappy_multichannel_stream, cores=cores)
+                out["{0}.{1}".format(name, cores)] = (cc_out, w)
             if "fftw" in name:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
@@ -279,10 +284,6 @@ def gappy_stream_cc_output_dict(
                         func, name, multichannel_templates,
                         gappy_multichannel_stream, cores=1, cores_outer=cores)
                 out["{0}.{1}_outer".format(name, cores)] = (cc_out, w)
-            with warnings.catch_warnings(record=True) as w:
-                cc_out = time_func(func, name, multichannel_templates,
-                                   gappy_multichannel_stream, cores=cores)
-                out["{0}.{1}".format(name, cores)] = (cc_out, w)
     return out
 
 
@@ -302,6 +303,10 @@ def gappy_real_cc_output_dict(
     for name, func in stream_funcs.items():
         for cores in [1, cpu_count()]:
             print("Running {0} with {1} cores".format(name, cores))
+            with warnings.catch_warnings(record=True) as w:
+                cc_out = time_func(func, name, gappy_real_data_template,
+                                   gappy_real_data, cores=cores)
+                out["{0}.{1}".format(name, cores)] = (cc_out, w)
             if "fftw" in name:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
@@ -311,10 +316,6 @@ def gappy_real_cc_output_dict(
                         func, name, gappy_real_data_template,
                         gappy_real_data, cores=1, cores_outer=cores)
                 out["{0}.{1}_outer".format(name, cores)] = (cc_out, w)
-            with warnings.catch_warnings(record=True) as w:
-                cc_out = time_func(func, name, gappy_real_data_template,
-                                   gappy_real_data, cores=cores)
-                out["{0}.{1}".format(name, cores)] = (cc_out, w)
     return out
 
 

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -256,10 +256,13 @@ def gappy_stream_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        with warnings.catch_warnings(record=True) as w:
-            cc_out = time_func(func, name, multichannel_templates,
-                               gappy_multichannel_stream, cores=1)
-            out[name] = (cc_out, w)
+        for cores in [1, 2]:
+            # Check for same result both single and multi-threaded
+            print("Running {0} with {1} cores".format(name, cores))
+            with warnings.catch_warnings(record=True) as w:
+                cc_out = time_func(func, name, multichannel_templates,
+                                   gappy_multichannel_stream, cores=cores)
+                out["{0}.{1}".format(name, cores)] = (cc_out, w)
     return out
 
 
@@ -277,10 +280,12 @@ def gappy_real_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        with warnings.catch_warnings(record=True) as w:
-            cc_out = time_func(func, name, gappy_real_data_template,
-                               gappy_real_data, cores=1)
-            out[name] = (cc_out, w)
+        for cores in [1, 2]:
+            print("Running {0} with {1} cores".format(name, cores))
+            with warnings.catch_warnings(record=True) as w:
+                cc_out = time_func(func, name, gappy_real_data_template,
+                                   gappy_real_data, cores=cores)
+                out["{0}.{1}".format(name, cores)] = (cc_out, w)
     return out
 
 

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -227,7 +227,7 @@ def gappy_real_data_template():
 
 # a dict of all registered stream functions (this is a bit long)
 stream_funcs = {fname + '_' + mname: corr.get_stream_xcorr(fname, mname)
-                for fname in corr.XCORR_FUNCS_ORIGINAL.keys()
+                for fname in sorted(corr.XCORR_FUNCS_ORIGINAL.keys())
                 for mname in corr.XCORR_STREAM_METHODS
                 if fname != 'default'}
 
@@ -244,7 +244,7 @@ def stream_cc_output_dict(multichannel_templates, multichannel_stream):
             cc_out = time_func(func, name, multichannel_templates,
                                multichannel_stream, cores=cores)
             out["{0}.{1}".format(name, cores)] = cc_out
-            if "fftw" in name:
+            if "fftw" in name and cores > 1:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
                 # result
@@ -275,7 +275,7 @@ def gappy_stream_cc_output_dict(
                 cc_out = time_func(func, name, multichannel_templates,
                                    gappy_multichannel_stream, cores=cores)
                 out["{0}.{1}".format(name, cores)] = (cc_out, w)
-            if "fftw" in name:
+            if "fftw" in name and cores > 1:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
                 # result
@@ -307,7 +307,7 @@ def gappy_real_cc_output_dict(
                 cc_out = time_func(func, name, gappy_real_data_template,
                                    gappy_real_data, cores=cores)
                 out["{0}.{1}".format(name, cores)] = (cc_out, w)
-            if "fftw" in name:
+            if "fftw" in name and cores > 1:
                 print("Running outer core parallel")
                 # Make sure that using both parallel methods gives the same
                 # result

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -11,6 +11,7 @@ from functools import wraps
 
 import numpy as np
 import pytest
+from multiprocessing import cpu_count
 from obspy import Trace, Stream, read
 
 import eqcorrscan.utils.correlate as corr
@@ -237,9 +238,10 @@ def stream_cc_output_dict(multichannel_templates, multichannel_stream):
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        cc_out = time_func(func, name, multichannel_templates,
-                           multichannel_stream, cores=1)
-        out[name] = cc_out
+        for cores in [1, cpu_count() * 2]:
+            cc_out = time_func(func, name, multichannel_templates,
+                               multichannel_stream, cores=cores)
+            out["{0}.{1}".format(name, cores)] = cc_out
     return out
 
 
@@ -256,7 +258,7 @@ def gappy_stream_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        for cores in [1, 2]:
+        for cores in [1, cpu_count() * 2]:
             # Check for same result both single and multi-threaded
             print("Running {0} with {1} cores".format(name, cores))
             with warnings.catch_warnings(record=True) as w:
@@ -280,7 +282,7 @@ def gappy_real_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        for cores in [1, 2]:
+        for cores in [1, cpu_count() * 2]:
             print("Running {0} with {1} cores".format(name, cores))
             with warnings.catch_warnings(record=True) as w:
                 cc_out = time_func(func, name, gappy_real_data_template,

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -238,7 +238,16 @@ def stream_cc_output_dict(multichannel_templates, multichannel_stream):
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        for cores in [1, cpu_count() * 2]:
+        for cores in [1, cpu_count()]:
+            print("Running {0} with {1} cores".format(name, cores))
+            if "fftw" in name:
+                print("Running outer core parallel")
+                # Make sure that using both parallel methods gives the same
+                # result
+                cc_out = time_func(
+                    func, name, multichannel_templates, multichannel_stream,
+                    cores=1, cores_outer=cores)
+                out["{0}.{1}_outer".format(name, cores)] = cc_out
             cc_out = time_func(func, name, multichannel_templates,
                                multichannel_stream, cores=cores)
             out["{0}.{1}".format(name, cores)] = cc_out
@@ -258,9 +267,18 @@ def gappy_stream_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        for cores in [1, cpu_count() * 2]:
+        for cores in [1, cpu_count()]:
             # Check for same result both single and multi-threaded
             print("Running {0} with {1} cores".format(name, cores))
+            if "fftw" in name:
+                print("Running outer core parallel")
+                # Make sure that using both parallel methods gives the same
+                # result
+                with warnings.catch_warnings(record=True) as w:
+                    cc_out = time_func(
+                        func, name, multichannel_templates,
+                        gappy_multichannel_stream, cores=1, cores_outer=cores)
+                out["{0}.{1}_outer".format(name, cores)] = (cc_out, w)
             with warnings.catch_warnings(record=True) as w:
                 cc_out = time_func(func, name, multichannel_templates,
                                    gappy_multichannel_stream, cores=cores)
@@ -282,8 +300,17 @@ def gappy_real_cc_output_dict(
     # corr._get_array_dicts(multichannel_templates, multichannel_stream)
     out = {}
     for name, func in stream_funcs.items():
-        for cores in [1, cpu_count() * 2]:
+        for cores in [1, cpu_count()]:
             print("Running {0} with {1} cores".format(name, cores))
+            if "fftw" in name:
+                print("Running outer core parallel")
+                # Make sure that using both parallel methods gives the same
+                # result
+                with warnings.catch_warnings(record=True) as w:
+                    cc_out = time_func(
+                        func, name, gappy_real_data_template,
+                        gappy_real_data, cores=1, cores_outer=cores)
+                out["{0}.{1}_outer".format(name, cores)] = (cc_out, w)
             with warnings.catch_warnings(record=True) as w:
                 cc_out = time_func(func, name, gappy_real_data_template,
                                    gappy_real_data, cores=cores)

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -582,8 +582,8 @@ class TestMatchObjectHeavy(unittest.TestCase):
     def setUpClass(cls):
         client = Client('NCEDC')
         cls.t1 = UTCDateTime(2004, 9, 28, 17)
-        cls.t2 = cls.t1 + 3600
         process_len = 3600
+        cls.t2 = cls.t1 + process_len
         # t1 = UTCDateTime(2004, 9, 28)
         # t2 = t1 + 80000
         # process_len = 80000
@@ -609,11 +609,14 @@ class TestMatchObjectHeavy(unittest.TestCase):
                     (tr.stats.network, tr.stats.station, tr.stats.channel))
         cls.template_stachans = list(set(template_stachans))
         bulk_info = [(stachan[0], stachan[1], '*', stachan[2],
-                      cls.t1, cls.t1 + process_len)
+                      cls.t1 - 5, cls.t2 + 5)
                      for stachan in template_stachans]
         # Just downloading an hour of data
         st = client.get_waveforms_bulk(bulk_info)
         st.merge(fill_value='interpolate')
+        st.trim(cls.t1, cls.t2)
+        for tr in st:
+            tr.data = tr.data[0:int(process_len * 100)]
         cls.unproc_st = st.copy()
         cls.st = pre_processing.shortproc(
             st, lowcut=2.0, highcut=9.0, filt_order=4, samp_rate=20.0,

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -310,7 +310,7 @@ class TestGappyData(unittest.TestCase):
             parallel_process=False)
         for family in party:
             print(len(family))
-            self.assertTrue(len(family) in [11, 1])
+            self.assertTrue(len(family) in [12, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)
@@ -687,7 +687,8 @@ class TestMatchObjectHeavy(unittest.TestCase):
             template.highcut = None
         party = tribe.detect(
             stream=self.st, threshold=8.0, threshold_type='MAD',
-            trig_int=6.0, daylong=False, plotvar=False, parallel_process=False)
+            trig_int=6.0, daylong=False, plotvar=False, parallel_process=False,
+            debug=2)
         self.assertEqual(len(party), 4)
         compare_families(
             party=party, party_in=self.party, float_tol=0.05,
@@ -699,10 +700,12 @@ class TestMatchObjectHeavy(unittest.TestCase):
         """Test the client_detect method."""
         client = Client('NCEDC')
         party = self.tribe.copy().client_detect(
-            client=client, starttime=self.t1, endtime=self.t2,
+            client=client, starttime=self.t1 + 2.75, endtime=self.t2,
             threshold=8.0, threshold_type='MAD', trig_int=6.0,
             daylong=False, plotvar=False)
-        self.assertEqual(len(party), 4)
+        compare_families(
+            party=party, party_in=self.party, float_tol=0.05,
+            check_event=False)
 
     @pytest.mark.flaky(reruns=2)
     @pytest.mark.network
@@ -710,13 +713,16 @@ class TestMatchObjectHeavy(unittest.TestCase):
         """Test the client_detect method."""
         client = Client('NCEDC')
         party = self.tribe.copy().client_detect(
-            client=client, starttime=self.t1, endtime=self.t2,
+            client=client, starttime=self.t1 + 2.75, endtime=self.t2,
             threshold=8.0, threshold_type='MAD', trig_int=6.0,
             daylong=False, plotvar=False, save_progress=True)
         self.assertTrue(os.path.isfile("eqcorrscan_temporary_party.tgz"))
         saved_party = Party().read("eqcorrscan_temporary_party.tgz")
         self.assertEqual(party, saved_party)
         os.remove("eqcorrscan_temporary_party.tgz")
+        compare_families(
+            party=party, party_in=self.party, float_tol=0.05,
+            check_event=False)
 
     @pytest.mark.network
     def test_party_lag_calc(self):

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1216,16 +1216,17 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                     if not np.allclose(
                             det.__dict__[key], check_det.__dict__[key],
                             atol=float_tol):
-                        print(key)
+                        print("{0}: new: {1}\tcheck-against: {2}".format(
+                            key, det.__dict__[key], check_det.__dict__[key]))
                     assert np.allclose(
                         det.__dict__[key], check_det.__dict__[key],
                         atol=float_tol)
                 elif isinstance(det.__dict__[key], UTCDateTime):
                     if not det.__dict__[key] == check_det.__dict__[key]:
-                        print(key)
-                    assert (
-                        abs(det.__dict__[key] -
-                            check_det.__dict__[key]) <= 0.1)
+                        print("{0}: new: {1}\tcheck-against: {2}".format(
+                            key, det.__dict__[key], check_det.__dict__[key]))
+                    assert (abs(
+                        det.__dict__[key] - check_det.__dict__[key]) <= 0.1)
                 elif key in ['template_name', 'id']:
                     continue
                     # Name relies on creation-time, which is checked elsewhere,

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1218,6 +1218,7 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                             atol=float_tol):
                         print("{0}: new: {1}\tcheck-against: {2}".format(
                             key, det.__dict__[key], check_det.__dict__[key]))
+                        print(det)
                     assert np.allclose(
                         det.__dict__[key], check_det.__dict__[key],
                         atol=float_tol)

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -295,12 +295,12 @@ class TestGappyData(unittest.TestCase):
             filt_order=4, length=10, prepick=0.5, catalog=catalog,
             client_id="GEONET", process_len=3600, swin="P")
         cls.st = cls.client.get_waveforms(
-            station="KHZ", network="NZ", channel="HH?", location="10",
+            station="KHZ", network="NZ", channel="HHZ", location="10",
             starttime=cls.starttime, endtime=cls.endtime)
 
     def test_gappy_data(self):
         gaps = self.st.get_gaps()
-        self.assertEqual(len(gaps), 3)
+        self.assertEqual(len(gaps), 1)
         start_gap = gaps[0][4]
         end_gap = gaps[0][5]
         party = self.tribe.client_detect(
@@ -309,7 +309,8 @@ class TestGappyData(unittest.TestCase):
             threshold_type="absolute", trig_int=2, plotvar=False,
             parallel_process=False)
         for family in party:
-            self.assertTrue(len(family) in [6, 1])
+            print(family)
+            self.assertTrue(len(family) in [5, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -307,13 +307,14 @@ class TestGappyData(unittest.TestCase):
             client=self.client, starttime=self.starttime,
             endtime=self.endtime, threshold=0.6,
             threshold_type="absolute", trig_int=2, plotvar=False,
-            parallel_process=False)
+            parallel_process=False, cores=1)
         for family in party:
             print(family)
-            self.assertTrue(len(family) in [5, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)
+        for family in party:
+            self.assertTrue(len(family) in [5, 1])
 
     def test_gappy_data_removal(self):
         party = self.tribe.client_detect(

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -745,6 +745,11 @@ class TestMatchObjectHeavy(unittest.TestCase):
         self.assertEqual(self.party, read_party(
             fname=os.path.join(os.path.abspath(os.path.dirname(__file__)),
                                'test_data', 'test_party.tgz')))
+        for ev1, ev2 in zip(catalog, chained_cat):
+            ev1.picks.sort(key=lambda p: p.time)
+            ev2.picks.sort(key=lambda p: p.time)
+        catalog.events.sort(key=lambda e: e.picks[0].time)
+        chained_cat.events.sort(key=lambda e: e.picks[0].time)
         for ev, chained_ev in zip(catalog, chained_cat):
             for i in range(len(ev.picks)):
                 for key in ev.picks[i].keys():

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -305,12 +305,11 @@ class TestGappyData(unittest.TestCase):
         end_gap = gaps[0][5]
         party = self.tribe.client_detect(
             client=self.client, starttime=self.starttime,
-            endtime=self.endtime, threshold=12,
-            threshold_type="MAD", trig_int=2, plotvar=False,
+            endtime=self.endtime, threshold=0.6,
+            threshold_type="absolute", trig_int=2, plotvar=False,
             parallel_process=False)
         for family in party:
-            print(len(family))
-            self.assertTrue(len(family) in [12, 1])
+            self.assertTrue(len(family) in [6, 1])
             for detection in family:
                 self.assertFalse(
                     start_gap <= detection.detect_time <= end_gap)

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -325,7 +325,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     fftwf_execute_dft_r2c(pb, image_ext, outb);
 
     //  Compute dot product
-//    #pragma omp parallel for num_threads(num_threads) private(i)
+    #pragma omp parallel for num_threads(num_threads) private(i)
     for (t = 0; t < n_templates; ++t){
         for (i = 0; i < N2; ++i)
         {
@@ -401,7 +401,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     }
 
     // Center and divide by length to generate scaled convolution
-    #pragma omp parallel for reduction(+:status,unused_corr) num_threads(num_threads) private(t)
+//    #pragma omp parallel for reduction(+:status,unused_corr) num_threads(num_threads) private(t)
     for(i = 1; i < (image_len - template_len + 1); ++i){
         if (var[i] >= ACCEPTED_DIFF && flatline_count[i] < template_len - 1) {
             double stdev = sqrt(var[i]);

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -411,7 +411,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
                     c /= stdev;
                     if (fabs(c > 1.01)){
-                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
+                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\n",
                                t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
                     }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -409,27 +409,33 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
             if (meanstd >= ACCEPTED_DIFF){
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
-//                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-//                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
-//                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
-//                  }
+                  if (55490 <= i && i <= 55510){
+                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
+                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
+                  }
                     c /= stdev;
-//                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-//                        printf("Normalized Correlation: %g\n", c);
-//                  }
+                  if (55499 <= i && i <= 55510){
+                        printf("Normalized Correlation: %g\n", c);
+                  }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
                 }
             }
             else {
                 unused_corr = 1;
+                if (55499 <= i && i <= 55510){
+                    printf("Ignored correlation: Index: %i\tVariance: %g\tFlatline: %i\n",
+                           i, var[i], flatline_count[i]);
+                }
             }
             if (var[i] <= WARN_DIFF){
                 variance_warning[0] += 1;
             }
         } else {
             unused_corr = 1;
-//            printf("Ignored correlation: Index: %i\tVariance: %g\tFlatline: %i\tMean * STD: %g\n",
-//                   i, var[i], flatline_count[i], meanstd);
+            if (55499 <= i && i <= 55510){
+                printf("Ignored correlation: Index: %i\tVariance: %g\tFlatline: %i\n",
+                       i, var[i], flatline_count[i]);
+            }
         }
     }
     if (unused_corr == 1){
@@ -534,7 +540,6 @@ int multi_normxcorr_fftw(float *templates, long n_templates, long template_len, 
     fftwf_complex **outb = NULL;
     fftwf_complex **out = NULL;
     fftwf_plan pa, pb, px;
-
 
     #ifdef N_THREADS
     /* num_threads_outer cannot be greater than the number of channels */
@@ -664,6 +669,7 @@ int multi_normxcorr_fftw(float *templates, long n_templates, long template_len, 
     px = fftwf_plan_dft_c2r_2d(n_templates, fft_len, out[0], ccc[0], FFTW_ESTIMATE);
 
     /* loop over the channels */
+    printf("Outer threads: %i\n", num_threads_outer);
     #pragma omp parallel for num_threads(num_threads_outer)
     for (i = 0; i < n_channels; ++i){
         int tid = 0; /* each thread has its own workspace */
@@ -672,6 +678,7 @@ int multi_normxcorr_fftw(float *templates, long n_templates, long template_len, 
         /* get the id of this thread */
         tid = omp_get_thread_num();
         #endif
+        printf("thread id: %i\n", tid);
         /* initialise memory to zero */
         memset(template_ext[tid], 0, (size_t) fft_len * n_templates * sizeof(float));
         memset(image_ext[tid], 0, (size_t) fft_len * sizeof(float));

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -410,12 +410,12 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
 //                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-//                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
-//                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
+                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
+                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
 //                  }
                     c /= stdev;
 //                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-//                        printf("Normalized Correlation: %g\n", c);
+                        printf("Normalized Correlation: %g\n", c);
 //                  }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
                 }

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -325,7 +325,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     fftwf_execute_dft_r2c(pb, image_ext, outb);
 
     //  Compute dot product
-    #pragma omp parallel for num_threads(num_threads)
+    #pragma omp parallel for num_threads(num_threads) private(i)
     for (t = 0; t < n_templates; ++t){
         for (i = 0; i < N2; ++i)
         {
@@ -409,12 +409,12 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
             if (meanstd >= ACCEPTED_DIFF){
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
-//                  if (17850 <= i && i <= 17860){
-//                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\t",
-//                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd);
+//                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
+//                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
+//                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
 //                  }
                     c /= stdev;
-//                  if (17850 <= i && i <= 17860){
+//                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
 //                        printf("Normalized Correlation: %g\n", c);
 //                  }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -325,7 +325,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     fftwf_execute_dft_r2c(pb, image_ext, outb);
 
     //  Compute dot product
-    #pragma omp parallel for num_threads(num_threads) private(i)
+//    #pragma omp parallel for num_threads(num_threads) private(i)
     for (t = 0; t < n_templates; ++t){
         for (i = 0; i < N2; ++i)
         {
@@ -410,10 +410,6 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
                     c /= stdev;
-                    if (fabs(c > 1.01)){
-                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\n",
-                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
-                    }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
                 }
             }
@@ -658,7 +654,6 @@ int multi_normxcorr_fftw(float *templates, long n_templates, long template_len, 
     px = fftwf_plan_dft_c2r_2d(n_templates, fft_len, out[0], ccc[0], FFTW_ESTIMATE);
 
     /* loop over the channels */
-    printf("Outer threads: %i\n", num_threads_outer);
     #pragma omp parallel for num_threads(num_threads_outer)
     for (i = 0; i < n_channels; ++i){
         int tid = 0; /* each thread has its own workspace */
@@ -667,7 +662,6 @@ int multi_normxcorr_fftw(float *templates, long n_templates, long template_len, 
         /* get the id of this thread */
         tid = omp_get_thread_num();
         #endif
-        printf("thread id: %i\n", tid);
         /* initialise memory to zero */
         memset(template_ext[tid], 0, (size_t) fft_len * n_templates * sizeof(float));
         memset(image_ext[tid], 0, (size_t) fft_len * sizeof(float));

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -401,7 +401,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     }
 
     // Center and divide by length to generate scaled convolution
-//    #pragma omp parallel for reduction(+:status,unused_corr) num_threads(num_threads) private(t)
+    #pragma omp parallel for reduction(+:status,unused_corr) num_threads(num_threads) private(t)
     for(i = 1; i < (image_len - template_len + 1); ++i){
         if (var[i] >= ACCEPTED_DIFF && flatline_count[i] < template_len - 1) {
             double stdev = sqrt(var[i]);

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -167,7 +167,7 @@ int normxcorr_fftw_threaded(float *templates, long template_len, long n_template
             flatline_count = 0;
         }
         stdev = sqrt(var);
-        if (var >= ACCEPTED_DIFF && flatline_count < template_len - 1) {
+        if (var >= ACCEPTED_DIFF && flatline_count < template_len - 2) {
             for (t = 0; t < n_templates; ++t){
                 float c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean ) / stdev;
                 status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
@@ -403,7 +403,7 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
     // Center and divide by length to generate scaled convolution
     #pragma omp parallel for reduction(+:status,unused_corr) num_threads(num_threads) private(t)
     for(i = 1; i < (image_len - template_len + 1); ++i){
-        if (var[i] >= ACCEPTED_DIFF && flatline_count[i] < template_len - 1) {
+        if (var[i] >= ACCEPTED_DIFF && flatline_count[i] < template_len - 2) {
             double stdev = sqrt(var[i]);
             for (t = 0; t < n_templates; ++t){
                 double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i] );

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -410,12 +410,12 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
 //                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
-                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
+//                        printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
+//                               t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
 //                  }
                     c /= stdev;
 //                  if (4999 <= i && i <= 5001 && flatline_count[i] > 0){
-                        printf("Normalized Correlation: %g\n", c);
+//                        printf("Normalized Correlation: %g\n", c);
 //                  }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
                 }

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -37,10 +37,14 @@
         #define N_THREADS omp_get_max_threads()
     #endif
 #endif
-#if defined(__linux__) || defined(__linux)
-    #define OUTER_SAFE 1
+#ifndef OUTER_SAFE
+    #if defined(__linux__) || defined(__linux)
+        #define OUTER_SAFE 1
+    #else
+        #define OUTER_SAFE 0
+    #endif
 #else
-    #define OUTER_SAFE 0
+    #define OUTER_SAFE 1
 #endif
 // Define minimum variance to compute correlations - requires some signal
 #define ACCEPTED_DIFF 1e-10 //1e-15

--- a/eqcorrscan/utils/src/multi_corr.c
+++ b/eqcorrscan/utils/src/multi_corr.c
@@ -409,33 +409,22 @@ int normxcorr_fftw_main(float *templates, long template_len, long n_templates,
             if (meanstd >= ACCEPTED_DIFF){
                 for (t = 0; t < n_templates; ++t){
                     double c = ((ccc[(t * fft_len) + i + startind] / (fft_len * n_templates)) - norm_sums[t] * mean[i]);
-                  if (55490 <= i && i <= 55510){
+                    c /= stdev;
+                    if (fabs(c > 1.01)){
                         printf("Template %i\tIndex: %i\tCorrelation: %g\tMean: %g\tVariance: %g\tStdev: %g\tMean * std: %g\tFlatline: %i\t",
                                t, i, ccc[(t * fft_len) + i + startind], mean[i], var[i], stdev, meanstd, flatline_count[i]);
-                  }
-                    c /= stdev;
-                  if (55499 <= i && i <= 55510){
-                        printf("Normalized Correlation: %g\n", c);
-                  }
+                    }
                     status += set_ncc(t, i, template_len, image_len, (float) c, used_chans, pad_array, ncc);
                 }
             }
             else {
                 unused_corr = 1;
-                if (55499 <= i && i <= 55510){
-                    printf("Ignored correlation: Index: %i\tVariance: %g\tFlatline: %i\n",
-                           i, var[i], flatline_count[i]);
-                }
             }
             if (var[i] <= WARN_DIFF){
                 variance_warning[0] += 1;
             }
         } else {
             unused_corr = 1;
-            if (55499 <= i && i <= 55510){
-                printf("Ignored correlation: Index: %i\tVariance: %g\tFlatline: %i\n",
-                       i, var[i], flatline_count[i]);
-            }
         }
     }
     if (unused_corr == 1){

--- a/setup.py
+++ b/setup.py
@@ -204,7 +204,11 @@ def get_extensions():
     exp_symbols = export_symbols("eqcorrscan/utils/src/libutils.def")
 
     if get_build_platform() not in ('win32', 'win-amd64'):
-        extra_link_args = ['-lm', '-lgomp']
+        if get_build_platform().startswith('freebsd'):
+            # Clang uses libomp, not libgomp
+            extra_link_args = ['-lm', '-lomp']
+        else:
+            extra_link_args = ['-lm', '-lgomp']
         extra_compile_args = ['-fopenmp']
         if all(arch not in get_build_platform()
                for arch in ['arm', 'aarch']):


### PR DESCRIPTION
### What does this PR do?

* Enforce pre-processing even when no filters or resampling is to be done to ensure gaps are properly processed (when called from `Tribe.detect`, `Template.detect` or `Tribe.client_detect`)
* BUG-FIX in `Tribe.client_detect` where data were processed from data  one sample too long resulting in minor differences in data processing (due to difference in FFT length) and therefore minor differences   in resulting correlations (~0.07 per channel).

### Why was it initiated?  Any relevant Issues?

Tests were sporadically failing when different lengths of data were download on the CI systems.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
