### PR TITLE
Add a script for testing installed EQcorrscan

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,10 @@
 * Stopped allowing outer-threading on OSX, clang openMP is not thread-safe
   for how we have this set-up. Inner threading is faster and more memory
   efficient anyway.
+* Added testing script (`test_eqcorrscan.py`, which will be installed to your
+  path on installation of EQcorrscan) that will download all the relevant 
+  data and run the tests on the installed package - no need to clone 
+  EQcorrscan to run tests!
 
 ## 0.3.1
 * Cleaned imports in utils modules

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ from os.path import join, dirname
 import pytest
 
 # ------------------------- Paths constants
-# these are added to pytest namespace for convinience if finding things
+# these are added to pytest namespace for convenience if finding things
 # eg test data
 
 PKG_PATH = join(dirname(__file__), 'eqcorrscan')

--- a/eqcorrscan/__init__.py
+++ b/eqcorrscan/__init__.py
@@ -19,7 +19,7 @@ from eqcorrscan.core.lag_calc import lag_calc  # NOQA
 from eqcorrscan.utils.correlate import (  # NOQA
     get_stream_xcorr, get_array_xcorr, register_array_xcorr)
 
-__all__ = ['core', 'utils', 'tutorials']
+__all__ = ['core', 'utils', 'tutorials', 'tests']
 
 __version__ = '0.3.1'
 

--- a/eqcorrscan/scripts/test_eqcorrscan.py
+++ b/eqcorrscan/scripts/test_eqcorrscan.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python
+"""
+Collect and run the EQcorrscan tests.
+
+:copyright:
+    EQcorrscan developers.
+
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""
+
+import os
+import logging
+import sys
+import pytest
+import requests
+import glob
+import zipfile
+import io
+import shutil
+
+import eqcorrscan
+from eqcorrscan import tests
+
+logging.basicConfig(
+    level=logging.INFO, stream=sys.stdout,
+    format="%(asctime)s\t%(name)s\t%(levelname)s\t%(message)s")
+Logger = logging.getLogger(__name__)
+
+VERSION = eqcorrscan.__version__
+TEST_PATH = os.path.dirname(tests.__file__)
+PKG_PATH = os.path.dirname(os.path.dirname(eqcorrscan.__file__))
+TAG_URL = "https://github.com/eqcorrscan/EQcorrscan/archive/{0}.zip".format(
+    VERSION)
+TEST_DATA_PATH = os.path.join(TEST_PATH, 'test_data')
+
+
+class cd:
+    """
+    Context manager for changing the current working directory.
+
+    From: https://stackoverflow.com/questions/431684/\
+    how-do-i-change-directory-cd-in-python/13197763#13197763
+    """
+    def __init__(self, newPath):
+        self.newPath = os.path.expanduser(newPath)
+
+    def __enter__(self):
+        self.savedPath = os.getcwd()
+        os.chdir(self.newPath)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.savedPath)
+
+
+def download_test_data():
+    """Check if test data are installed, and if not, download them"""
+    if os.path.isdir(TEST_DATA_PATH):
+        if len(glob.glob(TEST_DATA_PATH)) > 0:
+            Logger.info("Found test data at: {0}".format(TEST_DATA_PATH))
+            return
+    Logger.info("Downloading test data from github")
+    os.makedirs(TEST_DATA_PATH)
+    with cd(TEST_DATA_PATH):
+        # Get the whole zip for this release
+        Logger.info("Downloading from {0}".format(TAG_URL))
+        r = requests.get(TAG_URL)
+        assert r.ok
+        contents = zipfile.ZipFile(io.BytesIO(r.content))
+        # Files that we want, test-data, conftest.py and pytest.ini
+        test_data_path = "EQcorrscan-{0}/eqcorrscan/tests/test_data/".format(
+            VERSION)
+        conftest = "EQcorrscan-{0}/conftest.py".format(VERSION)
+        contents.extract(conftest, '.')
+        pytestini = "EQcorrscan-{0}/pytest.ini".format(VERSION)
+        contents.extract(pytestini, '.')
+        for file in contents.namelist():
+            if file.startswith(test_data_path):
+                contents.extract(file, '.')
+        test_data = glob.glob(
+            "EQcorrscan-{0}/eqcorrscan/tests/test_data/*".format(VERSION))
+        for test_file in test_data:
+            Logger.debug("Moving {0}".format(test_file))
+            shutil.move(test_file, ".")
+        Logger.debug("Moving {0} to {1}".format(conftest, PKG_PATH))
+        shutil.move(conftest, PKG_PATH)
+        Logger.debug("Moving {0} to {1}".format(pytestini, PKG_PATH))
+        shutil.move(pytestini, PKG_PATH)
+        shutil.rmtree("EQcorrscan-{0}".format(VERSION))
+    return
+
+
+def run_tests(arg_list):
+    """
+    Run the tests.
+    """
+    arg_list.extend(["--doctest-modules", "-p", "no:warnings", "--runslow"])
+    arg_list.extend(
+        ["--ignore", "EGG-INFO", "--ignore", "eqcorrscan/utils/lib"])
+    with cd(PKG_PATH):
+        pytest.main(args=arg_list)
+
+
+if __name__ == "__main__":
+    arg_list = sys.argv[1:]
+    download_test_data()
+    run_tests(arg_list=arg_list)
+

--- a/eqcorrscan/tests/__init__.py
+++ b/eqcorrscan/tests/__init__.py
@@ -1,0 +1,8 @@
+"""
+:copyright:
+    EQcorrscan developers.
+
+:license:
+    GNU Lesser General Public License, Version 3
+    (https://www.gnu.org/copyleft/lesser.html)
+"""

--- a/eqcorrscan/tests/correlate_test.py
+++ b/eqcorrscan/tests/correlate_test.py
@@ -8,6 +8,7 @@ import itertools
 import warnings
 from collections import defaultdict
 from functools import wraps
+from os.path import join
 
 import numpy as np
 import pytest
@@ -93,7 +94,7 @@ def generate_multichannel_templates():
 
 
 def read_gappy_real_template():
-    return [read("eqcorrscan/tests/test_data/DUWZ_template.ms")]
+    return [read(join(pytest.test_data_path, "DUWZ_template.ms"))]
 
 
 def read_gappy_real_data():

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1198,6 +1198,8 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
     party.sort()
     party_in.sort()
     for fam, check_fam in zip(party, party_in):
+        fam.detections.sort(key=lambda d: d.detect_time)
+        check_fam.detections.sort(key=lambda d: d.detect_time)
         for det, check_det in zip(fam.detections, check_fam.detections):
             for key in det.__dict__.keys():
                 if key == 'event':

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,3 @@
 [pytest]
-norecursedirs=eqcorrscan/doc .* eqcorrscan/scripts build pyasdf eqcorrscan/lib eqcorrscan/utils/src
+norecursedirs=eqcorrscan/doc .* eqcorrscan/scripts build pyasdf eqcorrscan/utils/lib eqcorrscan/utils/src
 addopts = --cov=eqcorrscan --cov-config .coveragerc --ignore=setup.py --doctest-modules -p no:warnings

--- a/setup.py
+++ b/setup.py
@@ -381,7 +381,7 @@ def setup_package():
     else:
         setup_args['packages'] = ['eqcorrscan', 'eqcorrscan.utils',
                                   'eqcorrscan.core', 'eqcorrscan.utils.lib',
-                                  'eqcorrscan.tutorials']
+                                  'eqcorrscan.tutorials', 'eqcorrscan.tests']
         setup_args['ext_modules'] = get_extensions()
         setup_args['package_data'] = get_package_data()
         setup_args['package_dir'] = get_package_dir()


### PR DESCRIPTION
### What does this PR do?

Adds a script that downloads the test-dataset (for that version of EQcorrscan), then runs the tests.

### Why was it initiated?  Any relevant Issues?

At the moment, users cannot simply test the installed version of EQcorrscan, and have to clone the repository and run tests there.  This is a bit of a faff and can lead to strange dependency mixtures. I would like it to be simple for people to run tests on their machines to encourage them to test the package before they run things. This script hopefully helps that.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
~~- [x] Any new features or fixed regressions are be covered via new tests.~~ This test-script is not "tested" by tests, but I have run it locally and should run it elsewhere.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
