### PR TITLE
Speed-up distance clustering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Future
+* BUG-FIX: `eqcorrscan.utils.mag_calc.dist_calc` calculated the long-way round
+  the Earth when changing hemispheres. We now use the Haversine formula, which
+  should give better results at short distances, and does not use a flat-Earth
+  approximation, so is better suited to larger distances as well.
+
 ## Current
 * Implement reading Party objects from multiple files, including wildcard
   expansion. This will only read template information if it was not 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,10 @@
   the Earth when changing hemispheres. We now use the Haversine formula, which
   should give better results at short distances, and does not use a flat-Earth
   approximation, so is better suited to larger distances as well.
+* Add C-openmp parallel distance-clustering (speed-ups of ~100 times).
+* Add time-clustering for catalogs and change how space-time cluster works
+  so that it uses the time-clustering, rather than just throwing out events
+  outside the time-range.
 
 ## Current
 * Implement reading Party objects from multiple files, including wildcard

--- a/eqcorrscan/tests/mag_calc_test.py
+++ b/eqcorrscan/tests/mag_calc_test.py
@@ -41,6 +41,8 @@ class TestMagCalcMethods(unittest.TestCase):
         self.assertEqual(round(dist_calc((90, 90, 0), (90, 90, 10))), 10)
         self.assertEqual(round(dist_calc((90, 90, 0), (90, 89, 0))), 0)
         self.assertEqual(round(dist_calc((90, 90, 0), (89, 90, 0))), 111)
+        self.assertEqual(round(dist_calc((0, 180, 0), (0, -179, 0))), 111)
+        self.assertEqual(round(dist_calc((0, -180, 0), (0, 179, 0))), 111)
 
     @pytest.mark.network
     @pytest.mark.flaky(reruns=2)

--- a/eqcorrscan/utils/mag_calc.py
+++ b/eqcorrscan/utils/mag_calc.py
@@ -56,20 +56,21 @@ def dist_calc(loc1, loc2):
     :returns: Distance between points in km.
     :rtype: float
     """
-    radius = 6371.009  # Radius of the Earth in km
+    from eqcorrscan.utils.libnames import _load_cdll
+    import ctypes
 
-    lat_1, lat_2 = (math.radians(loc1[0]), math.radians(loc2[0]))
-    lon_1, lon_2 = (math.radians(loc1[1]), math.radians(loc2[1]))
-    dlat = abs(lat_1 - lat_2)
-    dlong = abs(lon_1 - lon_2)
-    ddepth = abs(loc1[2] - loc2[2])
+    utilslib = _load_cdll('libutils')
 
-    central_angle = 2 * math.asin(math.sqrt(
-        math.pow(math.sin(dlat / 2), 2) +
-        math.cos(lat_1) * math.cos(lat_2) * math.pow(math.sin(dlong / 2), 2)))
+    utilslib.dist_calc.argtypes = [
+        ctypes.c_float, ctypes.c_float, ctypes.c_float,
+        ctypes.c_float, ctypes.c_float, ctypes.c_float]
+    utilslib.dist_calc.restype = ctypes.c_float
 
-    dist = radius * central_angle
-    dist = math.sqrt(dist ** 2 + ddepth ** 2)
+    dist = utilslib.dist_calc(
+        float(math.radians(loc1[0])), float(math.radians(loc1[1])),
+        float(loc1[2]),
+        float(math.radians(loc2[0])), float(math.radians(loc2[1])),
+        float(loc2[2]))
     return dist
 
 

--- a/eqcorrscan/utils/src/distance_cluster.c
+++ b/eqcorrscan/utils/src/distance_cluster.c
@@ -1,0 +1,91 @@
+/*
+ * =====================================================================================
+ *
+ *       Filename:  distance_cluster.c
+ *
+ *        Purpose:  Routines for calculating distance matrices between points
+ *
+ *        Created:  03/07/17 02:25:07
+ *       Revision:  none
+ *       Compiler:  gcc
+ *
+ *         Author:  Calum Chamberlain
+ *   Organization:  EQcorrscan
+ *      Copyright:  EQcorrscan developers.
+ *        License:  GNU Lesser General Public License, Version 3
+ *                  (https://www.gnu.org/copyleft/lesser.html)
+ *
+ * =====================================================================================
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <math.h>
+#if defined(__linux__) || defined(__linux) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(__NetBSD__)
+    #include <omp.h>
+    #ifndef N_THREADS
+        #define N_THREADS omp_get_max_threads()
+    #endif
+#endif
+
+#define EARTH_RADIUS 6371.009
+
+float dist_calc(float, float, float, float, float, float);
+
+int distance_matrix(float*, float*, float*, long, float*, int);
+
+float dist_calc(float lat1, float lon1, float depth1, float lat2, float lon2, float depth2){
+//    Function to calculate the distance in km between two points.
+//
+//    Uses the
+//    `haversine formula <https://en.wikipedia.org/wiki/Haversine_formula>`_
+//    to calculate great circle distance at the Earth's surface, then uses
+//    trig to include depth.
+//
+//    :type lat1: float - Latitude of point 1 in radians
+//    :type lon1: float - Longitude of point 1 in radians
+//    :type depth1: float - Depth of point 1 in km (positive down)
+//    :type lat2: float - Latitude of point 2 in radians
+//    :type lon2: float - Longitude of point 2 in radians
+//    :type depth2: float - Depth of point 2 in km (positive down)
+//    :type distance: float - Distance between two points (output, km)
+
+
+    double central_angle;
+    float dlat, dlong, ddepth, distance;
+
+    dlat = lat1 - lat2;
+    dlong = lon1 - lon2;
+    ddepth = depth1 - depth2;
+
+    central_angle = 2 * asin(sqrt(pow(sin(dlat / 2), 2) + cos(lat1) * cos(lat2) * pow(sin(dlong / 2), 2)));
+
+    distance = EARTH_RADIUS * central_angle;
+    distance = sqrt(pow(distance, 2) + pow(ddepth, 2));
+    return distance;
+}
+
+int distance_matrix(float *latitudes, float *longitudes, float *depths, long n_locs, float* dist_mat, int num_threads){
+    /* Calculate the distance matrix for a set of locations.
+    *
+    *  :type latitudes: Array of floats of latitudes in radians
+    *  :type longitudes: Array of floats of longitudes in radians
+    *  :type depths: Array of floats of depths in km (positive down)
+    *  :type n_locs: Number of locations
+    *  :type dist_mat: Array of floats of for output - should be initialized as zeros, and should be n_locs * n_locs
+    */
+    int out = 0;
+    long n;
+
+    #pragma omp parallel for num_threads(num_threads)
+    for (n = 0; n < n_locs * (n_locs + 1) / 2; ++n){
+        long j = n / (n_locs + 1), i = n % (n_locs + 1);
+        if (i > j){
+            j = n_locs - j - 1;
+            i = n_locs - i;
+        }
+        dist_mat[(i * n_locs) + j] = dist_calc(
+            latitudes[i], longitudes[i], depths[i], latitudes[j], longitudes[j], depths[j]);
+    }
+    return out;
+}

--- a/eqcorrscan/utils/src/libutils.def
+++ b/eqcorrscan/utils/src/libutils.def
@@ -8,3 +8,5 @@ EXPORTS
     multi_normxcorr_fftw
     multi_normxcorr_time
     multi_normxcorr_time_threaded
+    dist_calc
+    distance_matrix

--- a/eqcorrscan/utils/src/time_corr.c
+++ b/eqcorrscan/utils/src/time_corr.c
@@ -1,7 +1,7 @@
 /*
  * =====================================================================================
  *
- *       Filename:  multi_corr.c
+ *       Filename:  time_corr.c
  *
  *        Purpose:  Routines for computing cross-correlations in the time-domain
  *
@@ -9,7 +9,7 @@
  *       Revision:  none
  *       Compiler:  gcc
  *
- *         Author:  YOUR NAME (Calum Chamberlain),
+ *         Author:  Calum Chamberlain
  *   Organization:  EQcorrscan
  *      Copyright:  EQcorrscan developers.
  *        License:  GNU Lesser General Public License, Version 3

--- a/eqcorrscan/utils/timer.py
+++ b/eqcorrscan/utils/timer.py
@@ -53,6 +53,7 @@ def time_func(func, name, *args, **kwargs):
     print('%s took %0.2f seconds' % (name, toc - tic))
     return out
 
+
 if __name__ == "__main__":
     """Doc-test."""
     import doctest

--- a/setup.py
+++ b/setup.py
@@ -200,7 +200,9 @@ def get_extensions():
 
     sources = [os.path.join('eqcorrscan', 'utils', 'src', 'multi_corr.c'),
                os.path.join('eqcorrscan', 'utils', 'src', 'time_corr.c'),
-               os.path.join('eqcorrscan', 'utils', 'src', 'find_peaks.c')]
+               os.path.join('eqcorrscan', 'utils', 'src', 'find_peaks.c'),
+               os.path.join('eqcorrscan', 'utils', 'src',
+                            'distance_cluster.c')]
     exp_symbols = export_symbols("eqcorrscan/utils/src/libutils.def")
 
     if get_build_platform() not in ('win32', 'win-amd64'):


### PR DESCRIPTION
### What does this PR do?
Uses a c-extension to calculate the distance matrix for distance clustering.  Improves speed (using openmp looping), and makes the Python interface more standardised between different clustering methods.

### Why was it initiated?  Any relevant Issues?

Distance clustering is unnecessarily slow.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
