### PR TITLE
shortproc clip and dayproc one sample

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,9 @@
 * Correct test-script (`test_eqcorrscan.py`) to find paths properly.
 * BUG-FIX in `Party.decluster` when detections made at exactly the same time
   the first, rather than the highest of these was taken.
+* Catch one-sample difference in day properly in pre-processing.dayproc
+* Shortproc now clips and pads to the correct length asserted by starttime and
+  endtime.
 
 ## 0.3.2
 * Implement reading Party objects from multiple files, including wildcard

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -295,15 +295,16 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             if 80000 < data_len < 90000:
                 daylong = True
                 starttime = min([tr.stats.starttime for tr in st])
+                min_delta = min([tr.stats.delta for tr in st])
+                # Cope with the common starttime less than 1 sample before the
+                #  start of day.
+                if (starttime + min_delta).date > starttime.date:
+                    starttime = (starttime + min_delta)
                 # Check if this is stupid:
                 if abs(starttime - UTCDateTime(starttime.date)) > 600:
+                    print(abs(starttime - UTCDateTime(starttime.date)))
                     daylong = False
-                # Cope with the common starttime less than 1s before the
-                #  start of day.
-                if (starttime + 10).date > starttime.date:
-                    starttime = (starttime + 10).date
-                else:
-                    starttime = starttime.date
+                starttime = starttime.date
             else:
                 daylong = False
             if daylong:

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -172,12 +172,16 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
         raise IOError('Highcut must be lower than the nyquist')
     if debug > 4:
         parallel = False
+    length = None
+    clip = False
     if starttime is not None and endtime is not None:
         for tr in st:
             tr.trim(starttime, endtime)
             if len(tr.data) == ((endtime - starttime) *
                                 tr.stats.sampling_rate) + 1:
                 tr.data = tr.data[1:len(tr.data)]
+        length = endtime - starttime
+        clip = True
     elif starttime:
         for tr in st:
             tr.trim(starttime=starttime)
@@ -197,9 +201,9 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
         pool = Pool(processes=num_cores)
         results = [pool.apply_async(process, (tr,), {
             'lowcut': lowcut, 'highcut': highcut, 'filt_order': filt_order,
-            'samp_rate': samp_rate, 'debug': debug, 'starttime': False,
-            'clip': False, 'seisan_chan_names': seisan_chan_names,
-            'fill_gaps': fill_gaps})
+            'samp_rate': samp_rate, 'debug': debug, 'starttime': starttime,
+            'clip': clip, 'seisan_chan_names': seisan_chan_names,
+            'fill_gaps': fill_gaps, 'length': length})
                    for tr in st]
         pool.close()
         try:
@@ -213,8 +217,9 @@ def shortproc(st, lowcut, highcut, filt_order, samp_rate, debug=0,
         for i, tr in enumerate(st):
             st[i] = process(
                 tr=tr, lowcut=lowcut, highcut=highcut, filt_order=filt_order,
-                samp_rate=samp_rate, debug=debug, starttime=False, clip=False,
-                seisan_chan_names=seisan_chan_names, fill_gaps=fill_gaps)
+                samp_rate=samp_rate, debug=debug, starttime=starttime,
+                clip=clip, seisan_chan_names=seisan_chan_names,
+                fill_gaps=fill_gaps, length=length)
     if tracein:
         st.merge()
         return st[0]


### PR DESCRIPTION
### What does this PR do?

Copes with one the less than one-sample before day start for start times of GeoNet data - this is handled, but the order got muddled in 0.3.2 and shortproc was used rather than dayproc.
Shortproc also now clips based on set start and end times.
