### PR TITLE
Change Family.catalog to a property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,10 @@
 * Catch one-sample difference in day properly in pre-processing.dayproc
 * Shortproc now clips and pads to the correct length asserted by starttime and
   endtime.
+* Bug-fix: Match-filter collection objects (Tribe, Party, Family) implemented
+  addition (`__add__`) to alter the main object. Now the main object is left
+  unchanged.
+* `Family.catalog` is now an immutable property.
 
 ## 0.3.2
 * Implement reading Party objects from multiple files, including wildcard

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -2122,9 +2122,11 @@ class Tribe(object):
         .. rubric:: Example
 
         >>> tribe = Tribe(templates=[Template(name='a')])
-        >>> tribe + Tribe(templates=[Template(name='b')])
+        >>> tribe_ab = tribe + Tribe(templates=[Template(name='b')])
+        >>> print(tribe_ab)
         Tribe of 2 templates
-        >>> tribe + Template(name='c')
+        >>> tribe_abc = tribe_ab + Template(name='c')
+        >>> print(tribe_abc)
         Tribe of 3 templates
         """
         return self.copy().__iadd__(other)

--- a/eqcorrscan/core/match_filter.py
+++ b/eqcorrscan/core/match_filter.py
@@ -165,7 +165,22 @@ class Party(object):
         >>> print(party_a)
         Party of 2 Families.
         """
-        return self.__add__(other)
+        if isinstance(other, Family):
+            families = [other]
+        elif isinstance(other, Party):
+            families = other.families
+        else:
+            raise NotImplementedError(
+                'Ambiguous add, only allowed Party or Family additions.')
+        for oth_fam in families:
+            added = False
+            for fam in self.families:
+                if fam.template == oth_fam.template:
+                    fam += oth_fam
+                    added = True
+            if not added:
+                self.families.append(oth_fam)
+        return self
 
     def __add__(self, other):
         """
@@ -220,22 +235,7 @@ class Party(object):
         NotImplementedError: Ambiguous add, only allowed Party or Family \
         additions
         """
-        if isinstance(other, Family):
-            families = [other]
-        elif isinstance(other, Party):
-            families = other.families
-        else:
-            raise NotImplementedError(
-                'Ambiguous add, only allowed Party or Family additions.')
-        for oth_fam in families:
-            added = False
-            for fam in self.families:
-                if fam.template == oth_fam.template:
-                    fam += oth_fam
-                    added = True
-            if not added:
-                self.families.append(oth_fam)
-        return self
+        return self.copy().__iadd__(other)
 
     def __eq__(self, other, verbose=False):
         """
@@ -543,7 +543,6 @@ class Party(object):
                     d.threshold_type = new_threshold_type
                     rethresh_detections.append(d)
             family.detections = rethresh_detections
-            family.catalog = Catalog([d.event for d in family])
         return self
 
     def decluster(self, trig_int, timing='detect', metric='avg_cor'):
@@ -630,9 +629,7 @@ class Party(object):
             new_families.append(Family(
                 template=template,
                 detections=[d for d in declustered_detections
-                            if d.template_name == template_name],
-                catalog=Catalog([d.event for d in declustered_detections
-                                 if d.template_name == template_name])))
+                            if d.template_name == template_name]))
         self.families = new_families
         return self
 
@@ -804,15 +801,10 @@ class Party(object):
                         f for f in families if
                         f.template.name == family.template.name][0]
                     new_family = False
-                family.detections.extend(_read_family(
-                    fname=family_file, all_cat=all_cat, template=template[0]))
-                family.catalog = Catalog()
-                for detection in family.detections:
-                    if detection.event:
-                        family.catalog.append(detection.event)
+                family.detections = _read_family(
+                    fname=family_file, all_cat=all_cat, template=template[0])
                 if new_family:
                     families.append(family)
-
             shutil.rmtree(temp_dir)
         self.families = families
         return self
@@ -1042,16 +1034,24 @@ class Family(object):
     def __init__(self, template, detections=None, catalog=None):
         """Instantiation of Family object."""
         self.template = template
-        self.detections = []
-        self.catalog = Catalog()
         if isinstance(detections, Detection):
             detections = [detections]
-        if isinstance(catalog, Event):
-            catalog = Catalog(catalog)
-        if detections:
-            self.detections.extend(detections)
+        self.detections = detections or []
+        self.__catalog = get_catalog(self.detections)
         if catalog:
-            self.catalog.extend(catalog)
+            warnings.warn("Setting catalog directly is no-longer supported, "
+                          "now generated from detections.")
+
+    @property
+    def catalog(self):
+        if len(self.__catalog) != len(self.detections):
+            self.__catalog = get_catalog(self.detections)
+        return self.__catalog
+
+    @catalog.setter
+    def catalog(self, catalog):
+        raise NotImplementedError(
+            "Setting catalog directly is no-longer supported")
 
     def __repr__(self):
         """
@@ -1116,35 +1116,14 @@ class Family(object):
         NotImplementedError: Templates do not match
 
 
-        Can not extent a family with a list, or another object.
+        Cannot extent a family with a list, or another object.
 
         >>> family_a = Family(template=Template(name='a'))
         >>> family = family_a + ['albert'] # doctest: +IGNORE_EXCEPTION_DETAIL
         Traceback (most recent call last):
         NotImplementedError: Can only extend with a Detection of Family object.
         """
-        if isinstance(other, Family):
-            if other.template == self.template:
-                self.detections.extend(other.detections)
-                try:
-                    self.catalog += other.catalog
-                except TypeError:
-                    pass
-            else:
-                raise NotImplementedError('Templates do not match')
-        elif isinstance(other, Detection) and other.template_name \
-                == self.template.name:
-            self.detections.append(other)
-            try:
-                self.catalog += other.event
-            except TypeError:
-                pass
-        elif isinstance(other, Detection):
-            raise NotImplementedError('Template do not match')
-        else:
-            raise NotImplementedError('Can only extend with a Detection or '
-                                      'Family object.')
-        return self
+        return self.copy().__iadd__(other)
 
     def __iadd__(self, other):
         """
@@ -1158,7 +1137,22 @@ class Family(object):
         >>> print(family_a)
         Family of 0 detections from template a
         """
-        return self.__add__(other)
+        if isinstance(other, Family):
+            if other.template == self.template:
+                self.detections.extend(other.detections)
+                self.__catalog.events.extend(get_catalog(other.detections))
+            else:
+                raise NotImplementedError('Templates do not match')
+        elif isinstance(other, Detection) and other.template_name \
+                == self.template.name:
+            self.detections.append(other)
+            self.__catalog.events.extend(get_catalog([other]))
+        elif isinstance(other, Detection):
+            raise NotImplementedError('Templates do not match')
+        else:
+            raise NotImplementedError('Can only extend with a Detection or '
+                                      'Family object.')
+        return self
 
     def __eq__(self, other, verbose=False):
         """
@@ -1314,7 +1308,6 @@ class Family(object):
         [_detections.append(d) for d in self.detections
          if not _detections.count(d)]
         self.detections = _detections
-        self.catalog = get_catalog(self.detections)
         return self
 
     def sort(self):
@@ -2134,13 +2127,7 @@ class Tribe(object):
         >>> tribe + Template(name='c')
         Tribe of 3 templates
         """
-        if isinstance(other, Tribe):
-            self.templates += other.templates
-        elif isinstance(other, Template):
-            self.templates.append(other)
-        else:
-            raise TypeError('Must be either Template or Tribe')
-        return self
+        return self.copy().__iadd__(other)
 
     def __iadd__(self, other):
         """
@@ -2156,7 +2143,13 @@ class Tribe(object):
         >>> print(tribe)
         Tribe of 3 templates
         """
-        return self.__add__(other)
+        if isinstance(other, Tribe):
+            self.templates += other.templates
+        elif isinstance(other, Template):
+            self.templates.append(other)
+        else:
+            raise TypeError('Must be either Template or Tribe')
+        return self
 
     def __eq__(self, other):
         """
@@ -2658,7 +2651,6 @@ class Tribe(object):
             for family in party:
                 if family is not None:
                     family.detections = family._uniq().detections
-                    family.catalog = family._uniq().catalog
         return party
 
     def client_detect(self, client, starttime, endtime, threshold,
@@ -2924,7 +2916,6 @@ class Tribe(object):
         for family in party:
             if family is not None:
                 family.detections = family._uniq().detections
-                family.catalog = family._uniq().catalog
         if return_stream:
             return party, stream
         else:
@@ -3556,7 +3547,7 @@ def _group_detect(templates, stream, threshold, threshold_type, trig_int,
                 family = Family(template=template, detections=[])
                 for detection in detections:
                     if detection.template_name == template.name:
-                        family.append(detection)
+                        family.detections.append(detection)
                 party += family
     return party
 

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -901,8 +901,9 @@ class TestMatchObjectLight(unittest.TestCase):
         """Test add method"""
         added = self.tribe.copy()
         self.assertEqual(len(added + added[0]), 5)
+        self.assertEqual(len(added), 4)
         added += added[-1]
-        self.assertEqual(len(added), 6)
+        self.assertEqual(len(added), 5)
 
     def test_tribe_remove(self):
         """Test remove method"""
@@ -978,6 +979,8 @@ class TestMatchObjectLight(unittest.TestCase):
         test_party = self.party.copy()
         test_family = test_party[0]
         self.assertTrue(isinstance(test_family, Family))
+        self.assertEqual(len(test_party + test_family), 5)
+        self.assertEqual(len(test_party), 4)
         test_party += test_family
         self.assertEqual(len(test_party), 5)
         test_slice = test_party[0:2]
@@ -993,6 +996,8 @@ class TestMatchObjectLight(unittest.TestCase):
         test_slice.families.append(new_family)
         self.assertTrue(isinstance(test_slice, Party))
         self.assertEqual(len(test_slice), 4)
+        self.assertEqual(len(test_party + test_slice), 9)
+        self.assertEqual(len(test_party), 5)
         test_party += test_slice
         self.assertEqual(len(test_party), 9)
         with self.assertRaises(NotImplementedError):
@@ -1218,6 +1223,20 @@ class TestMatchObjectLight(unittest.TestCase):
         finally:
             if os.path.isfile('test_family.tgz'):
                 os.remove('test_family.tgz')
+
+    def test_family_catalogs(self):
+        """Check that the catalog always represents the detections"""
+        family = self.family.copy()
+        self.assertEqual(family.catalog, get_catalog(family.detections))
+        additional_detection = family.detections[0].copy()
+        additional_detection.detect_time += 3600
+        for pick in additional_detection.event.picks:
+            pick.time += 3600
+        added_family = family + additional_detection
+        self.assertEqual(added_family.catalog,
+                         get_catalog(added_family.detections))
+        family.detections.append(additional_detection)
+        self.assertEqual(family.catalog, get_catalog(family.detections))
 
 
 def compare_families(party, party_in, float_tol=0.001, check_event=True):


### PR DESCRIPTION
### What does this PR do?
Sets `Family.catalog` as a property, based on the detections in the Family.  It also alters how object addition is done.  Previously this was done inplace for both `+` and `+=`, which is not how it should be.

### Why was it initiated?  Any relevant Issues?
#272 
### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
