### PR TITLE
change C-flags for RedHat

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -270,39 +270,31 @@ class CustomBuildExt(build_ext):
         if "macosx" in get_build_platform() and "CFLAGS" in cfg_vars:
             print("System C-flags:")
             print(cfg_vars["CFLAGS"])
-            cflags = list(set(cfg_vars["CFLAGS"].split()))
-            if "-m" in cflags:
-                cflags.remove("-m")
-            if "-isysroot" in cflags:
-                cflags.remove("-isysroot")
-            # Remove sdk links
-            sdk_flags = []
-            for cflag in cflags:
-                if cflag.endswith(".sdk"):
-                    sdk_flags.append(cflag)
-            for cflag in sdk_flags:
-                cflags.remove(cflag)
-            cflags = list(set(cflags))
+            cflags = []
+            for flag in cfg_vars["CFLAGS"].split():
+                if flag in ["-m", "-isysroot"]:
+                    continue
+                # Remove sdk links
+                if flag.endswith(".sdk"):
+                    continue
+                cflags.append(flag)
             cfg_vars["CFLAGS"] = " ".join(cflags)
             print("Editted C-flags:")
             print(cfg_vars["CFLAGS"])
+        # Remove unsupported C-flags
+        unsupported_flags = [
+            "-fuse-linker-plugin", "-ffat-lto-objects", "-flto-partition=none"]
         for key in ["CFLAGS", "LDFLAGS", "LDSHARED"]:
             if key in cfg_vars:
-                print("System C-flags:")
+                print("System {0}:".format(key))
                 print(cfg_vars[key])
-                cflags = list(set(cfg_vars[key].split()))
-                if "-fuse-linker-plugin" in cflags:
-                    cflags.remove("-fuse-linker-plugin")
-                if "-ffat-lto-objects" in cflags:
-                    cflags.remove("-ffat-lto-objects")
-                if "-flto-partition=none" in cflags:
-                    cflags.remove("-flto-partition=none")
-                cflags = list(set(cflags))
-                if "gcc" in cflags:
-                    cflags.remove("gcc")
-                    cflags.insert(0, "gcc")
-                cfg_vars[key] = " ".join(cflags)
-                print("Editted C-flags:")
+                flags = []
+                for flag in cfg_vars[key].split():
+                    if flag in unsupported_flags:
+                        continue
+                    flags.append(flag)
+                cfg_vars[key] = " ".join(flags)
+                print("Editted {0}:".format(key))
                 print(cfg_vars[key])
 
         if compiler == 'msvc':

--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ def get_include_dirs():
     from pkg_resources import get_build_platform
 
     include_dirs = [os.path.join(os.getcwd(), 'include'),
-                    os.path.join(os.getcwd(), 'eqcorrscan', 'utils', 'lib'),
+                    os.path.join(os.getcwd(), 'eqcorrscan', 'utils', 'src'),
                     numpy.get_include(),
                     os.path.join(sys.prefix, 'include')]
 
@@ -292,7 +292,7 @@ class CustomBuildExt(build_ext):
                 print(cfg_vars[key])
                 cflags = list(set(cfg_vars[key].split()))
                 if "-fuse-linker-plugin" in cflags:
-                    cflags.remove("-fuse-linker-plugin") 
+                    cflags.remove("-fuse-linker-plugin")
                 if "-ffat-lto-objects" in cflags:
                     cflags.remove("-ffat-lto-objects")
                 if "-flto-partition=none" in cflags:


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?
Changes C-flags to remove unsupported flags.

### Why was it initiated?  Any relevant Issues?
A cluster running redhat failed to compile EQcorrscan. Removing these Cflags and linking flags fixed things.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
