### PR TITLE
Speedup correlation prep function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,12 @@
 * Refactored match-filter into smaller files. Namespace remains the same.
   This was done to ease maintenance - the match_filter.py file had become
   massive and was slow to load and process in IDEs.
+* Refactored `_prep_data_for_correlation` to reduce looping for speed, 
+  now approximately six times faster than previously (minor speed-up)
+  * Now explicitly doesn't allow templates with different length traces - 
+    previously this was ignored and templates with different length 
+    channels to other templates had their channels padded with zeros or 
+    trimmed.
 
 ## 0.3.3
 * Make test-script more stable.

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -248,6 +248,8 @@ class Detection(object):
                 continue
             elif tr.stats.__contains__("not_in_original"):
                 continue
+            elif np.all(np.isnan(tr.data)):
+                continue  # The channel contains no data and was not used.
             else:
                 pick_time = self.detect_time + (
                         tr.stats.starttime - min_template_tm)

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -576,15 +576,17 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     :returns: Newly cut template.
     :rtype: :class:`obspy.core.stream.Stream`
 
-    .. note:: By convention templates are generated with P-phases on the \
-        vertical channel and S-phases on the horizontal channels, normal \
-        seismograph naming conventions are assumed, where Z denotes vertical \
-        and N, E, R, T, 1 and 2 denote horizontal channels, either oriented \
-        or not.  To this end we will **only** use Z channels if they have a \
-        P-pick, and will use one or other horizontal channels **only** if \
+    .. note::
+        By convention templates are generated with P-phases on the
+        vertical channel and S-phases on the horizontal channels, normal
+        seismograph naming conventions are assumed, where Z denotes vertical
+        and N, E, R, T, 1 and 2 denote horizontal channels, either oriented
+        or not.  To this end we will **only** use Z channels if they have a
+        P-pick, and will use one or other horizontal channels **only** if
         there is an S-pick on it.
 
-    .. note:: swin argument: Setting to `P` will return only data for channels
+    .. note::
+        swin argument: Setting to `P` will return only data for channels
         with P picks, starting at the pick time (minus the prepick).
         Setting to `S` will return only data for channels with
         S picks, starting at the S-pick time (minus the prepick)
@@ -598,8 +600,9 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         channels. `S_all` will return cut traces starting at the S-pick
         time for all channels.
 
-    .. warning:: If there is no phase_hint included in picks, and swin=all, \
-        all channels with picks will be used.
+    .. warning::
+        If there is no phase_hint included in picks, and swin=all, all
+        channels with picks will be used.
     """
     from eqcorrscan.utils.plotting import pretty_template_plot as tplot
     from eqcorrscan.utils.plotting import noise_plot
@@ -616,23 +619,28 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
             Logger.warning(
                 "Pick not associated with waveform, will not use it: "
                 "{0}".format(pick))
-            picks_copy.remove(pick)
             continue
         if not pick.waveform_id.station_code or not \
                 pick.waveform_id.channel_code:
             Logger.warning(
                 "Pick not associated with a channel, will not use it:"
                 " {0}".format(pick))
-            picks_copy.remove(pick)
             continue
         picks_copy.append(pick)
+    if len(picks_copy) == 0:
+        return Stream()
+    st_copy = Stream()
     for tr in st:
         # Check that the data can be represented by float16, and check they
         # are not all zeros
         if np.all(tr.data.astype(np.float16) == 0):
             Logger.error("Trace is all zeros at float16 level, either gain or "
                          "check. Not using in template: {0}".format(tr))
-            st.remove(tr)
+            continue
+        st_copy += tr
+    st = st_copy
+    if len(st) == 0:
+        return st
     # Get the earliest pick-time and use that if we are not using delayed.
     picks_copy.sort(key=lambda p: p.time)
     first_pick = picks_copy[0]

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -417,8 +417,9 @@ def extract_from_stack(stack, template, length, pre_pick, pre_pad,
     :param highcut: If pre_processed=False then this is required, highcut in \
         Hz, defaults to False
     :type filt_order: int
-    :param filt_order: If pre_processed=False then this is required, filter \
-        order, defaults to False
+    :param filt_order:
+        If pre_processed=False then this is required, filter order, defaults
+        to False
 
     :returns: Newly cut template.
     :rtype: :class:`obspy.core.stream.Stream`
@@ -451,7 +452,7 @@ def extract_from_stack(stack, template, length, pre_pick, pre_pad,
                          " {0}.{1}".format(tr.stats.station, tr.stats.channel))
         else:
             for d in delay:
-                out += tr.trim(
+                out += tr.copy().trim(
                     starttime=tr.stats.starttime + d + pre_pad - pre_pick,
                     endtime=tr.stats.starttime + d + pre_pad + length -
                     pre_pick)

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1246,6 +1246,7 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
     party.sort()
     party_in.sort()
     for fam, check_fam in zip(party, party_in):
+        assert fam.template.name == check_fam.template.name
         fam.detections.sort(key=lambda d: d.detect_time)
         check_fam.detections.sort(key=lambda d: d.detect_time)
         for det, check_det in zip(fam.detections, check_fam.detections):
@@ -1294,6 +1295,8 @@ def compare_families(party, party_in, float_tol=0.001, check_event=True):
                     if not det.__dict__[key] == check_det.__dict__[key]:
                         print("{0}: new: {1}\tcheck-against: {2}".format(
                             key, det.__dict__[key], check_det.__dict__[key]))
+                        print(det)
+                        print(check_det)
                     assert (abs(
                         det.__dict__[key] - check_det.__dict__[key]) <= 0.1)
                 elif key in ['template_name', 'id']:

--- a/eqcorrscan/tests/pre_processing_test.py
+++ b/eqcorrscan/tests/pre_processing_test.py
@@ -359,6 +359,24 @@ class TestDataPrep(unittest.TestCase):
                 else:
                     self.assertEqual(tr, original_tr[0])
 
+    def test_duplicate_template_channels(self):
+        """
+        Check that duplicate template channels result in duplicate template
+        channels but not stream channels.
+        """
+        templates = deepcopy(self.stream_list)
+        templates.sort(key=lambda t: t[0].stats.starttime)
+        stream = deepcopy(self.stream_list[0])
+        additional_channel = templates[0][0]
+        additional_channel.stats.starttime += 30
+        templates[0] += additional_channel
+        assert len(templates[0]) == 10
+        continuous_data, templates = _prep_data_for_correlation(
+            stream=stream, templates=templates, force_stream_epoch=True)
+        for template in templates:
+            assert len(template) == 10
+        assert len(continuous_data) == 9
+
     def test_continuous_data_removal(self):
         """Check that data that should be removed are."""
         st = read()

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -910,7 +910,7 @@ def _get_array_dicts(templates, stream, stack, copy_streams=True):
         t_ar = np.array(temps_with_seed).astype(np.float32)
         template_dict.update({seed_id: t_ar})
         stream_channel = stream.select(id=seed_id.split('_')[0])[0]
-        # Normalize data to endure no float overflow
+        # Normalize data to ensure no float overflow
         stream_data = stream_channel.data / (np.max(
             np.abs(stream_channel.data)) / 1e5)
         stream_dict.update(

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -443,7 +443,7 @@ def cumulative_detections(dates=None, template_names=None, detections=None,
         fig = plt.figure()
         ax = fig.add_subplot(1, 1, 1)
     else:
-        fig = ax.figure()
+        fig = ax.get_figure()
     # Make sure not to pad at edges
     ax.margins(0, 0)
     min_date = min([min(_d) for _d in dates])

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -750,7 +750,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 channel_count += 1
             except IndexError:
                 # No channel or no duplicate channel, so NaN remains.
-                template_channel = nan_template[channel_number]
+                template_channel = nan_template[channel_number].copy()
                 template_channel.stats.starttime = template_starttime
             out_template += template_channel
         if channel_count > 0:


### PR DESCRIPTION
### What does this PR do?
Removes extraneous looping in `utils.pre_processing._prep_for_correlation` to improve speed.

### Why was it initiated?  Any relevant Issues?
This function was becoming a bottleneck for large template sets.  For a test template set of 1900 waveforms with many different channels the old implementation was taking > 30 seconds.  I managed to get this down to around 5 seconds.  It's still slow, but better.  I played around with threading as well, but the cost of starting the threads seems to mean that speed-ups are minimal and sometimes it takes longer threaded than in serial.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
