### PR TITLE
Add skip_short_channels arg to template_gen

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,10 @@
     previously this was ignored and templates with different length 
     channels to other templates had their channels padded with zeros or 
     trimmed.
+* Add `skip_short_channels` option to template generation.  This allows users 
+  to provide data of unknown length and short channels will not be used, rather
+  than generating an error. This is useful for downloading data from 
+  datacentres via the `from_client` method.
 
 ## 0.3.3
 * Make test-script more stable.

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -294,6 +294,9 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                 all_channels=all_channels)
         Logger.info('Pre-processing data')
         st.merge()
+        if len(st) == 0:
+            Logger.info("No data")
+            continue
         if process:
             data_len = max([len(tr.data) / tr.stats.sampling_rate
                             for tr in st])
@@ -317,7 +320,10 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             if skip_short_chans:
                 _st = Stream()
                 for tr in st:
-                    _len = tr.stats.endtime - tr.stats.starttime
+                    if np.ma.is_masked(tr.data):
+                        _len = np.ma.count(tr.data) * tr.stats.delta
+                    else:
+                        _len = tr.stats.npts * tr.stats.delta
                     if _len < process_len * .8:
                         Logger.info(
                             "Data for {0} are too short, skipping".format(
@@ -325,6 +331,9 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                     else:
                         _st += tr
                 st = _st
+                if len(st) == 0:
+                    Logger.info("No data")
+                    continue
             if daylong:
                 st = pre_processing.dayproc(
                     st=st, lowcut=lowcut, highcut=highcut,

--- a/eqcorrscan/tests/template_gen_test.py
+++ b/eqcorrscan/tests/template_gen_test.py
@@ -446,6 +446,17 @@ class TestEdgeGen(unittest.TestCase):
         template = _template_gen(self.picks, st, 10)
         self.assertEqual(len(template), 10)
 
+    @pytest.mark.network
+    def test_triggered_data(self):
+        client = Client("GEONET")
+        catalog = client.get_events(eventid="1481730")
+        templates = template_gen(
+            "from_client", lowcut=2., highcut=15., samp_rate=40., swin="all",
+            filt_order=4, prepick=0.2, catalog=catalog, length=3.0,
+            client_id="GEONET", all_horiz=True, process_len=600,
+            min_snr=5., skip_short_chans=True)
+        self.assertEqual(len(templates), 0)
+
 
 class TestDayLong(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
Thank your for contributing to EQcorrscan!

### What does this PR do?

Adds a `skip_short_channels` argument to `template_gen`.  This allows a user to provide data of unknown length to template_gen without an error occurring related to short data streams. This defaults to False to continue the old behaviour.

### Why was it initiated?  Any relevant Issues?

Using the `from_client` method, data can be downloaded from pre-continuous data times - this will allow `from_client` to ignore short, triggered traces and continue working.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
