### PR TITLE
Stop detection writing writing the header multiple times

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -50,6 +50,9 @@
   process-time will be supressed and empty traces returned.  This is useful 
   for downloading data from  datacentres via the `from_client` method when
   data quality is not known.
+* Fix #298 where the header was repeated in detection csv files. Also added
+  a `write_detections` function to `eqcorrscan.core.match_filter.detection`
+  to streamline writing detections.
 
 ## 0.3.3
 * Make test-script more stable.

--- a/eqcorrscan/core/match_filter/__init__.py
+++ b/eqcorrscan/core/match_filter/__init__.py
@@ -14,7 +14,8 @@ from eqcorrscan.core.match_filter.template import (  # NOQA
     Template, read_template)  # NOQA
 from eqcorrscan.core.match_filter.tribe import Tribe, read_tribe  # NOQA
 from eqcorrscan.core.match_filter.detection import (  # NOQA
-    Detection, read_detections, get_catalog, write_catalog)  # NOQA
+    Detection, read_detections, get_catalog, write_catalog,  #NOQA
+    write_detections)  # NOQA
 from eqcorrscan.core.match_filter.matched_filter import (  # NOQA
     MatchFilterError, match_filter)  # NOQA
 from eqcorrscan.core.match_filter.helpers import (  # NOQA
@@ -28,7 +29,8 @@ __all__ = [
     'Party', 'read_party', 'Family', 'Template', 'read_template', 'Tribe',
     'read_tribe', 'Detection', 'read_detections', 'get_catalog',
     'write_catalog', 'MatchFilterError',
-    'normxcorr2', 'extract_from_stream', '_spike_test', 'temporary_directory']
+    'normxcorr2', 'extract_from_stream', '_spike_test', 'temporary_directory',
+    'write_detections']
 
 
 if __name__ == '__main__':

--- a/eqcorrscan/core/match_filter/__init__.py
+++ b/eqcorrscan/core/match_filter/__init__.py
@@ -14,7 +14,7 @@ from eqcorrscan.core.match_filter.template import (  # NOQA
     Template, read_template)  # NOQA
 from eqcorrscan.core.match_filter.tribe import Tribe, read_tribe  # NOQA
 from eqcorrscan.core.match_filter.detection import (  # NOQA
-    Detection, read_detections, get_catalog, write_catalog,  #NOQA
+    Detection, read_detections, get_catalog, write_catalog,  # NOQA
     write_detections)  # NOQA
 from eqcorrscan.core.match_filter.matched_filter import (  # NOQA
     MatchFilterError, match_filter)  # NOQA

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -201,7 +201,7 @@ class Detection(object):
             'Channel list', 'Detection value', 'Threshold', 'Threshold type',
             'Input threshold', 'Detection type'])
         with open(fname, mode) as _f:
-            if not append:
+            if mode == "w":
                 _f.write(header + '\n')  # Write a header for the file
             _f.write(self._print_str() + '\n')
 
@@ -312,8 +312,6 @@ def read_detections(fname, encoding="UTF8"):
         lines = _f.read().decode(encoding).splitlines()
     detections = []
     for index, line in enumerate(lines):
-        if index == 0:
-            continue  # Skip header
         if line.rstrip().split('; ')[0] == 'Template name':
             continue  # Skip any repeated headers
         detection = line.rstrip().split('; ')

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -165,6 +165,12 @@ class Detection(object):
     def __ne__(self, other):
         return not self.__eq__(other)
 
+    def _print_str(self):
+        return "{0}; {1}; {2}; {3}; {4}; {5}; {6}; {7}; {8}".format(
+            self.template_name, self.detect_time, self.no_chans,
+            self.chans, self.detect_val, self.threshold,
+            self.threshold_type, self.threshold_input, self.typeofdet)
+
     def copy(self):
         """
         Returns a copy of the detection.
@@ -194,13 +200,10 @@ class Detection(object):
             'Template name', 'Detection time (UTC)', 'Number of channels',
             'Channel list', 'Detection value', 'Threshold', 'Threshold type',
             'Input threshold', 'Detection type'])
-        print_str = "{0}; {1}; {2}; {3}; {4}; {5}; {6}; {7}; {8}\n".format(
-            self.template_name, self.detect_time, self.no_chans,
-            self.chans, self.detect_val, self.threshold,
-            self.threshold_type, self.threshold_input, self.typeofdet)
         with open(fname, mode) as _f:
-            _f.write(header + '\n')  # Write a header for the file
-            _f.write(print_str)
+            if not append:
+                _f.write(header + '\n')  # Write a header for the file
+            _f.write(self._print_str() + '\n')
 
     def _calculate_event(self, template=None, template_st=None):
         """
@@ -261,6 +264,31 @@ class Detection(object):
                         location_code=tr.stats.location)))
         self.event = ev
         return
+
+
+def write_detections(detections, fname, mode='a'):
+    """
+    Write a list of detections to a file.
+
+    :type detections: List of Detection
+    :param detections: List of detection objects to write
+    :type fname: str
+    :param fname: Filename to write to
+    :type mode: str
+    :param mode: 'a' for append, or 'w' for write (will overwrite old files)
+    """
+    assert mode in {"a", "w"}
+    lines = []
+    if mode == "w" or not os.path.isfile(fname):
+        lines.append('; '.join([
+            'Template name', 'Detection time (UTC)', 'Number of channels',
+            'Channel list', 'Detection value', 'Threshold', 'Threshold type',
+            'Input threshold', 'Detection type']))
+    lines.extend([d._print_str() for d in detections])
+    lines = "\n".join(lines)
+    lines += "\n"
+    with open(fname, mode=mode) as f:
+        f.write(lines)
 
 
 def read_detections(fname, encoding="UTF8"):

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -34,6 +34,7 @@ from eqcorrscan.core.match_filter.matched_filter import (
     MatchFilterError, _group_process)
 from eqcorrscan.core.match_filter.template import Template
 from eqcorrscan.core.match_filter.family import Family
+from eqcorrscan.core.match_filter.detection import write_detections
 from eqcorrscan.core.match_filter.helpers import (
     _total_microsec, temporary_directory, _safemembers, _templates_match)
 
@@ -635,8 +636,8 @@ class Party(object):
                 raise MatchFilterError(
                     'Will not overwrite existing file: %s' % filename)
             for family in self.families:
-                for detection in family.detections:
-                    detection.write(fname=filename, append=True)
+                write_detections(fname=filename, detections=family.detections,
+                                 mode="a")
         elif format.lower() == 'tar':
             if os.path.exists(filename):
                 raise IOError('Will not overwrite existing file: %s'

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -743,7 +743,8 @@ class Party(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, parallel=True,
-                 overlap='calculate', process_cores=None):
+                 overlap='calculate', process_cores=None,
+                 ignore_bad_data=False):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -793,6 +794,11 @@ class Party(object):
         :param process_cores:
             Number of processes to use for pre-processing (if different to
             `cores`).
+        :type ignore_bad_data: bool
+        :param ignore_bad_data:
+            If False (default), errors will be raised if data are excessively
+            gappy or are mostly zeros. If True then no error will be raised,
+            but an empty trace will be returned (and not used in detection).
 
         :returns:
             Catalog of events with picks.  No origin information is included.
@@ -873,7 +879,8 @@ class Party(object):
                 processed_streams = _group_process(
                     template_group=group, cores=process_cores,
                     parallel=parallel, stream=stream.copy(), daylong=False,
-                    ignore_length=False, overlap=lap)
+                    ignore_length=False, overlap=lap,
+                    ignore_bad_data=ignore_bad_data)
                 processed_stream = Stream()
                 for p in processed_streams:
                     processed_stream += p

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -258,7 +258,7 @@ class ShortTests(unittest.TestCase):
         _xcorr_interp(ccc, 0.1)
         self.assertEqual(len(self.log_messages['warning']), 2)
         self.assertTrue(
-            'Less than 5 samples' in self.log_messages['warning'][0])
+            'Fewer than 5 samples' in self.log_messages['warning'][0])
         self.assertTrue(
             'Residual in quadratic fit' in self.log_messages['warning'][1])
 

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -1135,6 +1135,15 @@ class TestMatchObjectLight(unittest.TestCase):
             if os.path.isfile('test_party_out.tgz'):
                 os.remove('test_party_out.tgz')
 
+    def test_party_write_csv(self):
+        """ There was an issue (#298) where the header was repeated."""
+        party = Party().read()
+        party.write("test_party.csv", format="csv")
+        with open("test_party.csv", "rb") as f:
+            lines = f.read().decode().split("\n")
+        self.assertEqual(len(lines), 6)
+        os.remove("test_party.csv")
+
     def test_party_io_no_catalog_writing(self):
         """Test reading and writing party objects."""
         if os.path.isfile('test_party_out_no_cat.tgz'):


### PR DESCRIPTION
### What does this PR do?

Closes #298 - adds a `write_detections` function to `eqcorrscan.core.match_filter.detection` to streamline detection writing and fixes the `.write` method on `Detection` objects.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
