### PR TITLE
Decimate cccsum_hist properly to fix #179

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -59,6 +59,7 @@
 * Fix #298 where the header was repeated in detection csv files. Also added
   a `write_detections` function to `eqcorrscan.core.match_filter.detection`
   to streamline writing detections.
+* Fix #179 when decimating for cccsum_hist in `_match_filter_plot`
 
 ## 0.3.3
 * Make test-script more stable.

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -2270,8 +2270,7 @@ def _match_filter_plot(stream, cccsum, template_names, rawthresh, plotdir,
     cccsum_plot.stats.sampling_rate = stream[0].stats.sampling_rate
     # Resample here to maintain shape better
     cccsum_hist = cccsum_plot.copy()
-    cccsum_hist = cccsum_hist.decimate(int(stream[0].stats.
-                                           sampling_rate / 10)).data
+    cccsum_hist = _plotting_decimation(cccsum_hist, 10e5, 4).data
     cccsum_plot = chunk_data(cccsum_plot, 10, 'Maxabs').data
     # Enforce same length
     stream_plot.data = stream_plot.data[0:len(cccsum_plot)]


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Uses step-wise decimation for cccsum histogram in `_match_filter_plot`.

### Why was it initiated?  Any relevant Issues?

#179 

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
