### PR TITLE
add dir_save in function to save image of lag_calc

### DIFF
--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -444,7 +444,9 @@ def _prepare_data(detect_data, detections, template, delays,
 def lag_calc(detections, detect_data, template_names, templates,
              shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
              vertical_chans=['Z'], cores=1, interpolate=False,
-             plot=False, parallel=True, debug=0):
+             plot=False,dir_save=None, parallel=True, debug=0):
+    import os
+    import matplotlib.pyplot as plt
     """
     Main lag-calculation function for detections of specific events.
 
@@ -496,7 +498,9 @@ def lag_calc(detections, detect_data, template_names, templates,
     :param parallel: Turn parallel processing on or off.
     :type debug: int
     :param debug: Debug output level, 0-5 with 5 being the most output.
-
+    :param dir_save: path2save like "./output/lag_plot" and end of it without "/"
+        folder of date add automatic
+    :type dir_save: string of directory
 
     :returns:
         Catalog of events with picks.  No origin information is included.
@@ -642,6 +646,13 @@ def lag_calc(detections, detect_data, template_names, templates,
                             template_plot.remove(tr)
                     plot_repicked(template=template_plot, picks=event.picks,
                                   det_stream=plot_stream)
+                    # if set dir_save
+                    if dir_save != None:
+                        path2save = dir_save+'/'+event.resource_id.id[0:10]+'/'
+                        if not os.path.isdir(path2save):
+                            os.makedirs(path2save)
+                        plt.savefig(path2save + event.resource_id.id + '.png')
+                        plt.close(plt.gcf())
     # Order the catalogue to match the input
     output_cat = Catalog()
     for det in detections:

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -444,7 +444,7 @@ def _prepare_data(detect_data, detections, template, delays,
 def lag_calc(detections, detect_data, template_names, templates,
              shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
              vertical_chans=['Z'], cores=1, interpolate=False,
-             plot=False,dir_save=None, parallel=True, debug=0):
+             plot=False, dir_save=None, parallel=True, debug=0):
     import os
     import matplotlib.pyplot as plt
     """
@@ -498,7 +498,8 @@ def lag_calc(detections, detect_data, template_names, templates,
     :param parallel: Turn parallel processing on or off.
     :type debug: int
     :param debug: Debug output level, 0-5 with 5 being the most output.
-    :param dir_save: path2save like "./output/lag_plot" and end of it without "/"
+    :param dir_save:
+        path2save like "./output/lag_plot" and end of it without "/"
         folder of date add automatic
     :type dir_save: string of directory
 
@@ -647,7 +648,7 @@ def lag_calc(detections, detect_data, template_names, templates,
                     plot_repicked(template=template_plot, picks=event.picks,
                                   det_stream=plot_stream)
                     # if set dir_save
-                    if dir_save != None:
+                    if dir_save is not None:
                         path2save = dir_save+'/'+event.resource_id.id[0:10]+'/'
                         if not os.path.isdir(path2save):
                             os.makedirs(path2save)


### PR DESCRIPTION
1) without this part we must use 
>>> figures=[manager.canvas.figure for manager in matplotlib._pylab_helpers.Gcf.get_all_fig_managers()]
>>> for ii,fig in enumerate(figures):
>>>     fig.savefig('path/and/name/of/output.png')
2) but cant find what fig is relate to each template

<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
