### PR TITLE
format the output-filename on template_gen.py

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -99,6 +99,8 @@
   change the quality of correlations.
 * Removed depreciated `template_gen` functions and `bright_lights` and
   `seismo_logs`. See #315
+* BUG-FIX: `eqcorrscan.core.template_gen.py` fix conflict with special character on windows
+  output-filename. See issue #344
 
 ## 0.3.3
 * Make test-script more stable.

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -7,3 +7,4 @@
 * Chris Scott
 * Felix Halpaap
 * Iman Kahbasi
+* eQ Halauwet

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -403,7 +403,8 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             for template in temp_list:
                 template.write(
                     "eqcorrscan_temporary_templates{0}{1}.ms".format(
-                        os.path.sep, template[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
+                        os.path.sep, template[0].stats.starttime.strftime(
+                            "%Y-%m-%dT%H%M%S")),
                     format="MSEED")
         del st
     if return_event:
@@ -828,11 +829,13 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         tplot(st1, background=stplot, picks=picks_copy,
               title='Template for ' + str(st1[0].stats.starttime),
               savefile="{0}/{1}_template.png".format(
-                  plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
+                  plotdir, st1[0].stats.starttime.strftime(
+                      "%Y-%m-%dT%H%M%S")),
               **plot_kwargs)
         noise_plot(signal=st1, noise=noise,
                    savefile="{0}/{1}_noise.png".format(
-                       plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
+                       plotdir, st1[0].stats.starttime.strftime(
+                           "%Y-%m-%dT%H%M%S")),
                    **plot_kwargs)
         del stplot
     return st1

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -403,7 +403,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             for template in temp_list:
                 template.write(
                     "eqcorrscan_temporary_templates{0}{1}.ms".format(
-                        os.path.sep, template[0].stats.starttime),
+                        os.path.sep, template[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
                     format="MSEED")
         del st
     if return_event:
@@ -828,11 +828,11 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
         tplot(st1, background=stplot, picks=picks_copy,
               title='Template for ' + str(st1[0].stats.starttime),
               savefile="{0}/{1}_template.png".format(
-                  plotdir, st1[0].stats.starttime),
+                  plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
               **plot_kwargs)
         noise_plot(signal=st1, noise=noise,
                    savefile="{0}/{1}_noise.png".format(
-                       plotdir, st1[0].stats.starttime),
+                       plotdir, st1[0].stats.starttime.strftime("%Y-%m-%dT%H%M%S")),
                    **plot_kwargs)
         del stplot
     return st1

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -2218,7 +2218,8 @@ def _match_filter_plot(stream, cccsum, template_names, rawthresh, plotdir,
     cccsum_plot = cccsum_plot[0:len(stream_plot.data)]
     cccsum_hist = cccsum_hist[0:len(stream_plot.data)]
     plot_name = "{0}/cccsum_plot_{1}_{2}.{3}".format(
-        plotdir, template_names[i], stream[0].stats.starttime, plot_format)
+        plotdir, template_names[i], stream[0].stats.starttime.strftime(
+                  "%Y-%m-%dT%H%M%S"), plot_format)
     plot_kwargs = dict(show=True)
     if plotdir is not None:
         if not os.path.isdir(plotdir):


### PR DESCRIPTION
Found an issue when construct template with option "plotdir" or "save_progress" on windows10, which can't use special character on the filename. So I added string format "strftime("%Y-%m-%dT%H%M%S")" for the default output-filename.

<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?
Format output filename to fix conflict with special character on windows filename

### Why was it initiated?  Any relevant Issues?
https://github.com/eqcorrscan/EQcorrscan/issues/344

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
