### PR TITLE
Patch for #381 - only return events used.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 * core.template_gen
   - BUG-FIX: Fix bug where events were incorrectly associated with templates
     in `Tribe().construct()` if the given catalog contained events outside
-    of the time-range of the stream. See issue #381 and PR #
+    of the time-range of the stream. See issue #381 and PR #382.
 * utils.catalog_to_dd
   - Added ability to turn off parallel processing (this is turned off by 
     default now) for `write_correlations` - parallel processing for moderate

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 ## Current
+* core.template_gen
+  - BUG-FIX: Fix bug where events were incorrectly associated with templates
+    in `Tribe().construct()` if the given catalog contained events outside
+    of the time-range of the stream. See issue #381 and PR #
 * utils.catalog_to_dd
   - Added ability to turn off parallel processing (this is turned off by 
     default now) for `write_correlations` - parallel processing for moderate

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -288,6 +288,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
 
     temp_list = []
     process_lengths = []
+    catalog_out = Catalog()
 
     if "P_all" in swin or "S_all" in swin or all_horiz:
         all_channels = True
@@ -396,6 +397,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                 plotdir=plotdir)
             process_lengths.append(len(st[0].data) / samp_rate)
             temp_list.append(template)
+            catalog_out += event
         if save_progress:
             if not os.path.isdir("eqcorrscan_temporary_templates"):
                 os.makedirs("eqcorrscan_temporary_templates")
@@ -407,7 +409,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                     format="MSEED")
         del st
     if return_event:
-        return temp_list, catalog, process_lengths
+        return temp_list, catalog_out, process_lengths
     return temp_list
 
 

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -600,7 +600,8 @@ class TestTribeConstruction(unittest.TestCase):
         for template in tribe:
             self.assertEqual(process_len, template.process_length)
             for tr in template.st:
-                self.assertEqual(tr.stats.npts / tr.stats.sampling_rate, length)
+                self.assertEqual(tr.stats.npts / tr.stats.sampling_rate,
+                                 length)
                 matched_pick = [p for p in template.event.picks
                                 if p.waveform_id.get_seed_string() == tr.id
                                 and p.phase_hint == swin]

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -571,6 +571,46 @@ class TestMatchCopy(unittest.TestCase):
         self.assertEqual(tribe, copied)
 
 
+@pytest.mark.network
+class TestTribeConstruction(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        client = Client("GEONET")
+        cat = client.get_events(
+            latitude=-41.7, longitude=174.1, maxradius=0.5, minmagnitude=4.0,
+            starttime=UTCDateTime(2013, 7, 30),
+            endtime=UTCDateTime(2013, 8, 2))
+        cls.cat, cls.client = cat, client
+
+    def test_short_stream(self):
+        """ Check that events are correctly associated with templates, #381"""
+        process_len = 3600
+        length = 6
+        swin = "P"
+
+        st = self.client.get_waveforms(
+            network="NZ", station="TCW", location="10", channel="EHZ",
+            starttime=UTCDateTime(2013, 7, 31, 23),
+            endtime=UTCDateTime(2013, 8, 1))
+        tribe = Tribe().construct(
+            method="from_meta_file", lowcut=2, highcut=10, samp_rate=50,
+            filt_order=4, length=length, prepick=0.5, st=st,
+            meta_file=self.cat, swin=swin, process_len=process_len)
+        self.assertEqual(len(tribe), 2)
+        for template in tribe:
+            self.assertEqual(process_len, template.process_length)
+            for tr in template.st:
+                self.assertEqual(tr.stats.npts / tr.stats.sampling_rate, length)
+                matched_pick = [p for p in template.event.picks
+                                if p.waveform_id.get_seed_string() == tr.id
+                                and p.phase_hint == swin]
+                if len(matched_pick) == 0:
+                    continue
+                self.assertLessEqual(
+                    abs(matched_pick[0].time -
+                        tr.stats.starttime) - template.prepick, tr.stats.delta)
+
+
 class TestMatchObjectHeavy(unittest.TestCase):
     @classmethod
     @pytest.mark.flaky(reruns=2)
@@ -1193,7 +1233,6 @@ class TestMatchObjectLight(unittest.TestCase):
         self.assertEqual(len(lines), 6)
         os.remove("test_party.csv")
 
-    # TODO: Track down where prepick has been incorrectly applied.
     def test_party_io_no_catalog_writing(self):
         """Test reading and writing party objects."""
         if os.path.isfile('test_party_out_no_cat.tgz'):


### PR DESCRIPTION
## What does this PR do?

Events outside of the data span were incorrectly returned by template_gen, resulting in `Tribe().construct` assigning the wrong event metadata to templates if the catalogue provided contained events outside the span of the stream provided.

Commit summary:
- Fix bug #381
- Needs test

### Why was it initiated?  Any relevant Issues?
#381 

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
