### PR TITLE
Check full seed

### DIFF
--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -56,7 +56,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                  all_horiz=False, delayed=True, plot=False, plotdir=None,
                  return_event=False, min_snr=None, parallel=False,
                  num_cores=False, save_progress=False, skip_short_chans=False,
-                 **kwargs):
+                 check_full_seed=False, **kwargs):
     """
     Generate processed and cut waveforms for use as templates.
 
@@ -120,6 +120,13 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         Whether to ignore channels that have insufficient length data or not.
         Useful when the quality of data is not known, e.g. when downloading
         old, possibly triggered data from a datacentre
+    :type check_full_seed: bool
+    :param check_full_seed:
+        If True, will check the trace header against the full SEED id,
+        including Network, Station, Location and Channel. If False (default),
+        will check only against Station and Channel. This behavior was
+        originally necessary to cope with some software (i.e. SEISAN) not
+        storing picks with full SEED info.
 
     :returns: List of :class:`obspy.core.stream.Stream` Templates
     :rtype: list
@@ -394,7 +401,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             template = _template_gen(
                 event.picks, st, length, swin, prepick=prepick, plot=plot,
                 all_horiz=all_horiz, delayed=delayed, min_snr=min_snr,
-                plotdir=plotdir)
+                plotdir=plotdir, check_full_seed=check_full_seed)
             process_lengths.append(len(st[0].data) / samp_rate)
             temp_list.append(template)
             catalog_out += event

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -589,7 +589,7 @@ def _rms(array):
 
 def _template_gen(picks, st, length, swin='all', prepick=0.05,
                   all_horiz=False, delayed=True, plot=False, min_snr=None,
-                  plotdir=None):
+                  plotdir=None, check_full_seed=False):
     """
     Master function to generate a multiplexed template for a single event.
 
@@ -635,6 +635,13 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     :param plotdir:
         The path to save plots to. If `plotdir=None` (default) then the figure
         will be shown on screen.
+    :type check_full_seed: bool
+    :param check_full_seed:
+        If True, will check the trace header against the full SEED id,
+        including Network, Station, Location and Channel. If False (default),
+        will check only against Station and Channel. This behavior was
+        originally necessary to cope with some software (i.e. SEISAN) not
+        storing picks with full SEED info.
 
     :returns: Newly cut template.
     :rtype: :class:`obspy.core.stream.Stream`
@@ -714,11 +721,25 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     starttimes = []
     for _swin in swin:
         for tr in st:
-            starttime = {'station': tr.stats.station,
-                         'channel': tr.stats.channel, 'picks': []}
-            station_picks = [pick for pick in picks_copy
-                             if pick.waveform_id.station_code ==
-                             tr.stats.station]
+            if check_full_seed:
+                starttime = {'network': tr.stats.network,
+                             'station': tr.stats.station,
+                             'location': tr.stats.location,
+                             'channel': tr.stats.channel,
+                             'picks': []}
+                station_picks = [pick for pick in picks_copy
+                                 if pick.waveform_id.network_code ==
+                                 tr.stats.network and
+                                 pick.waveform_id.station_code ==
+                                 tr.stats.station and
+                                 pick.waveform_id.location_code ==
+                                 tr.stats.location]
+            else:
+                starttime = {'station': tr.stats.station,
+                             'channel': tr.stats.channel, 'picks': []}
+                station_picks = [pick for pick in picks_copy
+                                 if pick.waveform_id.station_code ==
+                                 tr.stats.station]
             if _swin == 'P_all':
                 p_pick = [pick for pick in station_picks
                           if pick.phase_hint.upper()[0] == 'P']


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?
Uses full SEED information (adds network and location) when comparing e.g. pick.waveform_id and tr.stats in a number of functions. Mostly importantly template_gen, but may also include mag_calc and others. 

### Why was it initiated?  Any relevant Issues?
 #388 

In situations where the desired template or trace contains unique picks with the same Station and Channel, but different location and/or Network codes (e.g. separate sensors in one borehole), current behavior does not differentiate between them.

### PR Checklist
- [x] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
