### PR TITLE
Add travis testing on Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ matrix:
       env: PYTHON_VERSION=3.7 MKL=1 PYTEST=1
     - os: linux
       env: PYTHON_VERSION=3.7 MKL=0 PYTEST=0
+    - os: linux
+      env: PYTHON_VERSION=3.8 MKL=1 PYTEST=0
     - os: osx
       osx_image: xcode8
       env:
@@ -20,6 +22,9 @@ matrix:
     - os: osx
       env:
         - PYTHON_VERSION=3.7 MKL=1 PYTEST=0
+    - os: osx
+      env:
+        - PYTHON_VERSION=3.8 MKL=1 PYTEST=0
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - conda install h5py
   - if [ "$MKL" == "1" ]; then conda install -q mkl mkl-include; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda install llvm-openmp>=4.0.1;
+      conda install clangdev>=4 openmp>=4 libcxx>=4 cctools clang clang_osx-64 compiler-rt libcxx llvm-openmp>=4.0.1;
     fi
   - pip install pep8-naming pytest pytest-cov pytest-pep8 pytest-xdist pytest-rerunfailures pytest-mpl codecov Cython
   - pip freeze

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,17 @@ matrix:
     - os: linux
       env: PYTHON_VERSION=3.7 MKL=0 PYTEST=0
     - os: linux
-      env: PYTHON_VERSION=3.8 MKL=1 PYTEST=0
+      env: PYTHON_VERSION=3.8 MKL=1 PYTEST=1
     - os: osx
       osx_image: xcode8
       env:
-        - PYTHON_VERSION=3.6 MKL=1 PYTEST=0
+        - PYTHON_VERSION=3.6 MKL=1 PYTEST=1
     - os: osx
       env:
-        - PYTHON_VERSION=3.7 MKL=1 PYTEST=0
+        - PYTHON_VERSION=3.7 MKL=1 PYTEST=1
     - os: osx
       env:
-        - PYTHON_VERSION=3.8 MKL=1 PYTEST=0
+        - PYTHON_VERSION=3.8 MKL=1 PYTEST=1
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,7 +56,7 @@ install:
   - conda install h5py
   - if [ "$MKL" == "1" ]; then conda install -q mkl mkl-include; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda install clangdev=4 openmp=4 libcxx=4 cctools clang clang_osx-64 compiler-rt libcxx llvm;
+      conda install llvm-openmp>=4.0.1;
     fi
   - pip install pep8-naming pytest pytest-cov pytest-pep8 pytest-xdist pytest-rerunfailures pytest-mpl codecov Cython
   - pip freeze

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,9 @@ environment:
     - PYTHON: "C:\\Miniconda35-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Miniconda35-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
 
 install:
   - '.\\misc\\appveyor\\trim_path.bat'


### PR DESCRIPTION
### What does this PR do?

Add test-running for Python 3.8 prior to conda-forge building.  This PR will be an attempt to fix some failing tests as well.

### Why was it initiated?  Any relevant Issues?

Anaconda defaults to Python 3.8 for new environments now, but EQcorrscan is not built for Python 3.8.  We should build for 3.8, but we need to test first.