### PR TITLE
Zero length processed data

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,11 @@
     of 1 (rather than 2080 as per Wood Anderson specs).
   - Added `filter_id` and `method_id` to amplitudes to make these methods more
     traceable.
+* core.match_filter
+  - Bug-fix - cope with data that are too short with `ignore_bad_data=True`.
+    This flag is generally not advised, but when used, may attempt to trim all
+    data to zero length.  The expected behaviour is to remove bad data and run
+    with the remaining data.
   
 ## 0.4.1
 * core.match_filter

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -322,13 +322,14 @@ def _group_process(template_group, parallel, cores, stream, daylong,
                                  for tr in chunk_stream]
         if min(_chunk_stream_lengths) >= .8 * process_length:
             _processed_stream = func(st=chunk_stream, **kwargs)
-            # If data have more zeros then pre-processing will return a trace of 0 length
+            # If data have more zeros then pre-processing will return a 
+            # trace of 0 length
             _processed_stream.traces = [
                 tr for tr in _processed_stream if tr.stats.npts != 0]
-            # Pre-procesing does additional checks for zeros - we need to check 
+            # Pre-procesing does additional checks for zeros - we need to check
             # again whether we actually have something useful from this.
             processed_chunk_stream_lengths = [
-                tr.stats.endtime - tr.stats.starttime 
+                tr.stats.endtime - tr.stats.starttime
                 for tr in _processed_stream]
             if min(processed_chunk_stream_lengths) >= .8 * process_length:
                 processed_streams.append(_processed_stream)

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -322,6 +322,9 @@ def _group_process(template_group, parallel, cores, stream, daylong,
                                  for tr in chunk_stream]
         if min(_chunk_stream_lengths) >= .8 * process_length:
             _processed_stream = func(st=chunk_stream, **kwargs)
+            # If data have more zeros then pre-processing will return a trace of 0 length
+            _processed_stream.traces = [
+                tr for tr in _processed_stream if tr.stats.npts != 0]
             # Pre-procesing does additional checks for zeros - we need to check 
             # again whether we actually have something useful from this.
             processed_chunk_stream_lengths = [

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -322,7 +322,7 @@ def _group_process(template_group, parallel, cores, stream, daylong,
                                  for tr in chunk_stream]
         if min(_chunk_stream_lengths) >= .8 * process_length:
             _processed_stream = func(st=chunk_stream, **kwargs)
-            # If data have more zeros then pre-processing will return a 
+            # If data have more zeros then pre-processing will return a
             # trace of 0 length
             _processed_stream.traces = [
                 tr for tr in _processed_stream if tr.stats.npts != 0]

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -683,6 +683,18 @@ class TestMatchObjectHeavy(unittest.TestCase):
             party=party, party_in=self.party, float_tol=0.05,
             check_event=True)
 
+    def test_tribe_detect_short_data(self):
+        """Test the detect method on Tribe objects"""
+        short_st = self.unproc_st.copy()
+        tribe = self.tribe.copy()
+        for template in tribe:
+            template.process_length = 2400
+        party = tribe.detect(
+            stream=short_st, threshold=8.0, threshold_type='MAD',
+            trig_int=6.0, daylong=False, plotvar=False, parallel_process=False,
+            ignore_bad_data=True)
+        self.assertEqual(len(party), 4)
+
     @pytest.mark.serial
     def test_tribe_detect_parallel_process(self):
         """Test the detect method on Tribe objects"""

--- a/eqcorrscan/tests/pre_processing_test.py
+++ b/eqcorrscan/tests/pre_processing_test.py
@@ -239,6 +239,16 @@ class TestPreProcessing(unittest.TestCase):
             seisan_chan_names=True, ignore_length=True)
         self.assertEqual(processed.stats.npts, 86400)
 
+    def test_short_data_empty_return(self):
+        """Check that we do not data that is too short ignore_length is True."""
+        processed = process(
+            tr=self.st[0].copy().trim(endtime=self.
+                                      st[0].stats.endtime - 28000), lowcut=0.1,
+            highcut=0.4, filt_order=3, samp_rate=1,
+            starttime=self.day_start, clip=True, length=86400,
+            seisan_chan_names=True, ignore_bad_data=True)
+        self.assertEqual(processed.stats.npts, 0)
+
     def test_highcut_debug(self):
         """Test a basic process implementation with just a highcut"""
         processed = process(tr=self.st[0].copy(), lowcut=None, highcut=0.4,

--- a/eqcorrscan/tests/pre_processing_test.py
+++ b/eqcorrscan/tests/pre_processing_test.py
@@ -241,7 +241,7 @@ class TestPreProcessing(unittest.TestCase):
 
     def test_short_data_empty_return(self):
         """
-        Check that we do not include data that is too short even if 
+        Check that we do not include data that is too short even if
         ignore_bad_data is True.
         """
         processed = process(

--- a/eqcorrscan/tests/pre_processing_test.py
+++ b/eqcorrscan/tests/pre_processing_test.py
@@ -240,7 +240,10 @@ class TestPreProcessing(unittest.TestCase):
         self.assertEqual(processed.stats.npts, 86400)
 
     def test_short_data_empty_return(self):
-        """Check that we do not data that is too short ignore_length is True."""
+        """
+        Check that we do not include data that is too short even if 
+        ignore_bad_data is True.
+        """
         processed = process(
             tr=self.st[0].copy().trim(endtime=self.
                                       st[0].stats.endtime - 28000), lowcut=0.1,


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Allows `ignore_bad_data=True` flag to be used to ignore bad traces.

### Why was it initiated?  Any relevant Issues?

Currently if `ignore_bad_data=True` and traces less than 80% of the required length are found, data from these will be removed, however the stats for these traces remain.  Due to some sloppy hard-coding, data are trimmed to the length of the zeroth trace, which might be length 0. This PR checks if there are 0-length traces and removes those.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
