### PR TITLE
Add distance thresholding to declustering

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -20,6 +20,11 @@
     This flag is generally not advised, but when used, may attempt to trim all
     data to zero length.  The expected behaviour is to remove bad data and run
     with the remaining data.
+  - Party:
+    - decluster now accepts a hypocentral_separation argument. This allows
+      the inclusion of detections that occur close in time, but not in space.
+      This is underwritten by a new findpeaks.decluster_dist_time function
+      based on a new C-function.
 * utils.pre_processing
   - Only templates that need to be reshaped are reshaped now - this can be a lot
     faster.

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -540,7 +540,8 @@ class Party(object):
                                "hypocentral separation")
                 catalog = None
 
-        assert metric in ('avg_cor', 'cor_sum'), 'metric is not cor_sum or avg_cor'
+        assert metric in ('avg_cor', 'cor_sum'), \
+            'metric is not cor_sum or avg_cor'
         assert timing in ('detect', 'origin'), 'timing is not detect or origin'
         if timing == 'detect':
             if metric == 'avg_cor':
@@ -570,7 +571,8 @@ class Party(object):
                 hypocentral_separation=hypocentral_separation)
         else:
             peaks_out = decluster(
-                peaks=detect_vals, index=detect_times, trig_int=trig_int * 10 ** 6)
+                peaks=detect_vals, index=detect_times,
+                trig_int=trig_int * 10 ** 6)
         # Need to match both the time and the detection value
         declustered_detections = []
         for ind in peaks_out:

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -32,7 +32,7 @@ from eqcorrscan.core.match_filter.helpers import (
     _total_microsec, temporary_directory, _safemembers, _templates_match)
 
 from eqcorrscan.utils.catalog_utils import _get_origin
-from eqcorrscan.utils.findpeaks import decluster
+from eqcorrscan.utils.findpeaks import decluster, decluster_distance_time
 from eqcorrscan.utils.plotting import cumulative_detections
 
 Logger = logging.getLogger(__name__)
@@ -471,7 +471,8 @@ class Party(object):
             family.detections = rethresh_detections
         return self
 
-    def decluster(self, trig_int, timing='detect', metric='avg_cor'):
+    def decluster(self, trig_int, timing='detect', metric='avg_cor',
+                  hypocentral_separation=None):
         """
         De-cluster a Party of detections by enforcing a detection separation.
 
@@ -492,6 +493,11 @@ class Party(object):
         :param timing:
             Either 'detect' or 'origin' to decluster based on either the
             detection time or the origin time.
+        :type hypocentral_separation: float
+        :param hypocentral_separation:
+            Maximum inter-event separation in km to decluster events within.
+            If an event happens within this distance of another event, and
+            within the trig_int defined time, then they will be declustered.
 
         .. Warning::
             Works in place on object, if you need to keep the original safe
@@ -505,41 +511,66 @@ class Party(object):
         >>> declustered = party.decluster(20)
         >>> len(party)
         3
+
+        .. rubric:: Example using epicentral-distance
+
+        >>> party = Party().read()
+        >>> len(party)
+        4
+        >>> # Calculate the expected origins based on the template origin.
+        >>> for family in party:
+        ...     for detection in family:
+        ...         _ = detection._calculate_event(template=family.template)
+        >>> declustered = party.decluster(20, hypocentral_separation=1)
+        >>> len(party)
+        4
+        >>> declustered = party.decluster(20, hypocentral_separation=100)
+        >>> len(party)
+        3
         """
         if self.__len__() == 0:
             return self
-        all_detections = []
-        for fam in self.families:
-            all_detections.extend(fam.detections)
+        all_detections = [d for fam in self.families for d in fam.detections]
+        catalog = None
+        if hypocentral_separation:
+            catalog = Catalog([d.event for fam in self.families
+                               for d in fam.detections if d.event])
+            if len(catalog) == 0:
+                Logger.warning("Detections do not have events, cannot use "
+                               "hypocentral separation")
+                catalog = None
+
+        assert metric in ('avg_cor', 'cor_sum'), 'metric is not cor_sum or avg_cor'
+        assert timing in ('detect', 'origin'), 'timing is not detect or origin'
         if timing == 'detect':
             if metric == 'avg_cor':
                 detect_info = [(d.detect_time, d.detect_val / d.no_chans)
                                for d in all_detections]
-            elif metric == 'cor_sum':
+            else:
                 detect_info = [(d.detect_time, d.detect_val)
                                for d in all_detections]
-            else:
-                raise MatchFilterError('metric is not cor_sum or avg_cor')
-        elif timing == 'origin':
+        else:
             if metric == 'avg_cor':
                 detect_info = [(_get_origin(d.event).time,
                                 d.detect_val / d.no_chans)
                                for d in all_detections]
-            elif metric == 'cor_sum':
+            else:
                 detect_info = [(_get_origin(d.event).time, d.detect_val)
                                for d in all_detections]
-            else:
-                raise MatchFilterError('metric is not cor_sum or avg_cor')
-        else:
-            raise MatchFilterError('timing is not detect or origin')
         min_det = sorted([d[0] for d in detect_info])[0]
         detect_vals = np.array([d[1] for d in detect_info], dtype=np.float32)
         detect_times = np.array([
             _total_microsec(d[0].datetime, min_det.datetime)
             for d in detect_info])
         # Trig_int must be converted from seconds to micro-seconds
-        peaks_out = decluster(
-            peaks=detect_vals, index=detect_times, trig_int=trig_int * 10 ** 6)
+        if hypocentral_separation and catalog:
+            peaks_out = decluster_distance_time(
+                peaks=detect_vals, index=detect_times,
+                trig_int=trig_int * 10 ** 6, catalog=catalog,
+                hypocentral_separation=hypocentral_separation)
+        else:
+            peaks_out = decluster(
+                peaks=detect_vals, index=detect_times, trig_int=trig_int * 10 ** 6)
         # Need to match both the time and the detection value
         declustered_detections = []
         for ind in peaks_out:

--- a/eqcorrscan/tests/find_peaks_test.py
+++ b/eqcorrscan/tests/find_peaks_test.py
@@ -56,8 +56,9 @@ class TestDeclustering:
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
         ])
-        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
-                                            hypocentral_separation, threshold=0)
+        peaks_out = decluster_distance_time(
+            peaks, index, trig_int, catalog, hypocentral_separation,
+            threshold=0)
         assert len(peaks) > len(peaks_out)
         assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
                              (65.0, 5000)]
@@ -74,8 +75,9 @@ class TestDeclustering:
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
         ])
-        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
-                                            hypocentral_separation, threshold=0)
+        peaks_out = decluster_distance_time(
+            peaks, index, trig_int, catalog, hypocentral_separation,
+            threshold=0)
         assert len(peaks) == len(peaks_out)
         assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
                              (65.0, 5000), (20.0, 10)]
@@ -93,8 +95,9 @@ class TestDeclustering:
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
             Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
         ])
-        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
-                                            hypocentral_separation, threshold=0)
+        peaks_out = decluster_distance_time(
+            peaks, index, trig_int, catalog, hypocentral_separation,
+            threshold=0)
         assert len(peaks) == len(peaks_out)
 
 

--- a/eqcorrscan/tests/find_peaks_test.py
+++ b/eqcorrscan/tests/find_peaks_test.py
@@ -6,10 +6,96 @@ from os.path import join
 import numpy as np
 import pytest
 
+from obspy.core.event import Catalog, Event, Origin
+
 from eqcorrscan.utils.findpeaks import (
     find_peaks2_short, coin_trig, multi_find_peaks, find_peaks_compiled,
-    _multi_find_peaks_c, _find_peaks_c)
+    _multi_find_peaks_c, _find_peaks_c, decluster, decluster_distance_time)
 from eqcorrscan.utils.timer import time_func
+
+
+class TestDeclustering:
+    def test_unclustered_time(self):
+        """ Check that nothing is lost if there aren't any clustered events."""
+        peaks = np.array([100, 65, 20, 120, 300])
+        index = np.array([2000, 5000, 10, 70, 500])
+        trig_int = 30
+        peaks_out = decluster(peaks, index, trig_int, threshold=0)
+        assert len(peaks) == len(peaks_out)
+        assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
+                             (65.0, 5000), (20.0, 10)]
+
+    def test_clustered_time(self):
+        """ Check that the smallest is removed. """
+        peaks = np.array([100, 65, 20, 120, 300])
+        index = np.array([2000, 5000, 10, 70, 500])
+        trig_int = 100
+        peaks_out = decluster(peaks, index, trig_int, threshold=0)
+        assert len(peaks) > len(peaks_out)
+        assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
+                             (65.0, 5000)]
+
+    def test_clustered_time_longlong(self):
+        """ Check that the smallest is removed when longlong func is used. """
+        peaks = np.array([100, 65, 20, 120, 300], dtype=np.float32)
+        index = np.array([2000, 5000, 10, 70, 500])
+        index = index * int(1e10)
+        trig_int = 100 * int(1e10)
+        peaks_out = decluster(peaks, index, trig_int, threshold=0)
+        assert len(peaks) > len(peaks_out)
+
+    def test_clustered_dist_time(self):
+        peaks = np.array([100, 65, 20, 120, 300])
+        index = np.array([2000, 5000, 10, 70, 500])
+        trig_int = 100
+        hypocentral_separation = 10.0
+        catalog = Catalog([
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+        ])
+        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
+                                            hypocentral_separation, threshold=0)
+        assert len(peaks) > len(peaks_out)
+        assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
+                             (65.0, 5000)]
+
+    def test_separated_dist(self):
+        peaks = np.array([100, 65, 20, 120, 300])
+        index = np.array([2000, 5000, 10, 70, 500])
+        trig_int = 100
+        hypocentral_separation = 10.0
+        catalog = Catalog([
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=80.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+        ])
+        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
+                                            hypocentral_separation, threshold=0)
+        assert len(peaks) == len(peaks_out)
+        assert peaks_out == [(300.0, 500), (120.0, 70), (100.0, 2000),
+                             (65.0, 5000), (20.0, 10)]
+
+    def test_separated_dist_longlong(self):
+        peaks = np.array([100, 65, 20, 120, 300])
+        index = np.array([2000, 5000, 10, 70, 500])
+        index = index * int(1e10)
+        trig_int = 100 * int(1e10)
+        hypocentral_separation = 10.0
+        catalog = Catalog([
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=80.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+            Event(origins=[Origin(latitude=0.0, longitude=90.0, depth=1000.)]),
+        ])
+        peaks_out = decluster_distance_time(peaks, index, trig_int, catalog,
+                                            hypocentral_separation, threshold=0)
+        assert len(peaks) == len(peaks_out)
 
 
 class TestStandardPeakFinding:

--- a/eqcorrscan/utils/src/find_peaks.c
+++ b/eqcorrscan/utils/src/find_peaks.c
@@ -19,6 +19,70 @@
  */
 #include <libutils.h>
 
+// Decluster in distance and time
+int decluster_dist_time(float *arr, long *indexes, float *distances,
+                        long len, float thresh, long trig_int,
+                        float dist_thresh, unsigned int *out){
+    // Takes a sorted array, with indexes as the time between events, and the
+    // distances as a distance matrix sorted in the same way.
+    long i, j, step;
+    int keep, distance_index;
+
+    if (fabs(arr[0]) < thresh){return 0;}
+
+    // Take first (highest) peak
+    out[0] = 1;
+    for (i = 1; i < len; ++i){
+        keep = 1;
+        // Threshold is for absolute values
+        if (fabs(arr[i]) < thresh){
+            break;
+        }
+        for (j = 0; j < i; ++j){
+            distance_index = (i * len) + j;
+            step = labs(indexes[i] - indexes[j]);
+
+            if (trig_int >= step && out[j] == 1 && distances[distance_index] < dist_thresh){
+                keep = 0;
+                break;
+            }
+        }
+        out[i] = keep;
+    }
+    return 0;
+}
+
+int decluster_dist_time_ll(float *arr, long long *indexes, float *distances,
+                           long long len, float thresh, long long trig_int,
+                           float dist_thresh, unsigned int *out){
+    // Takes a sorted array, with indexes as the time between events, and the
+    // distances as a distance matrix sorted in the same way.
+    long long i, j, step;
+    int keep, distance_index;
+
+    if (fabs(arr[0]) < thresh){return 0;}
+
+    // Take first (highest) peak
+    out[0] = 1;
+    for (i = 1; i < len; ++i){
+        keep = 1;
+        // Threshold is for absolute values
+        if (fabs(arr[i]) < thresh){
+            break;
+        }
+        for (j = 0; j < i; ++j){
+            distance_index = (i * len) + j;
+            step = llabs(indexes[i] - indexes[j]);
+            if (trig_int >= step && out[j] == 1 && distances[distance_index] < dist_thresh){
+                keep = 0;
+                break;
+            }
+        }
+        out[i] = keep;
+    }
+    return 0;
+}
+
 
 // Functions for long longs
 int decluster_ll(float *arr, long long *indexes, long long len,

--- a/eqcorrscan/utils/src/libutils.def
+++ b/eqcorrscan/utils/src/libutils.def
@@ -4,6 +4,8 @@ EXPORTS
     multi_find_peaks
     decluster
     decluster_ll
+    decluster_dist_time
+    decluster_dist_time_ll
     multi_decluster
     multi_decluster_ll
     normxcorr_fftw

--- a/eqcorrscan/utils/src/libutils.h
+++ b/eqcorrscan/utils/src/libutils.h
@@ -51,6 +51,11 @@
 #define WARN_DIFF 1e-8 //1e-10
 
 // find_peaks functions
+int decluster_dist_time_ll(float*, long long*, float*, long long, float,
+                           long long, float, unsigned int*);
+
+int decluster_dist_time(float*, long*, float*, long, float, long, float, unsigned int*);
+
 int decluster_ll(float*, long long*, long long, float, long long, unsigned int*);
 
 int multi_decluster_ll(float*, long long*, long long*, int, float*, long long, unsigned int*, int);


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Adds the ability to set a maximum hypocentral separation for declustering.  This means that events that are detected close in time, but in different places can be retained.

### Why was it initiated?  Any relevant Issues?

I wanted this for RT-EQcorrscan, so I did it.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
