### PR TITLE
Saving correlation data as npy file in lag_calc

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,5 @@
 ## Current
+* Added the ability of saving correlation data of the lag_calc.
 * utils.mag_calc.calc_b_value:
   - Added useful information to doc-string regarding method and meaning of
     residuals

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -190,7 +190,7 @@ def _concatenate_and_correlate(streams, template, cores):
 def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
                       horizontal_chans=['E', 'N', '1', '2'],
                       vertical_chans=['Z'], cores=1, interpolate=False,
-                      plot=False, plotdir=None, npy=False, npydir=None):
+                      plot=False, plotdir=None, export_cc=False, cc_dir=None):
     """
     Compute cross-correlation picks for detections in a family.
 
@@ -227,12 +227,12 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
     :type plotdir: str
     :param plotdir:
         Path to plotting folder, plots will be output here.
-    :type npy: bool
-    :param npy:
+    :type export_cc: bool
+    :param export_cc:
         To generate a binary file in NumPy for every detection or not,
         defaults to False
-    :type npydir: str
-    :param npydir:
+    :type cc_dir: str
+    :param cc_dir:
         Path to saving folder, NumPy files will be output here.
 
     :return: Dictionary of picked events keyed by detection id.
@@ -257,9 +257,9 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
     for i, detection_id in enumerate(detection_ids):
         detection = [d for d in family.detections if d.id == detection_id][0]
         correlations = ccc[i]
-        if npy:
-            os.makedirs(npydir, exist_ok=True)
-            np.save(os.path.join(npydir, detection_id+'.npy'), correlations)
+        if export_cc:
+            os.makedirs(cc_dir, exist_ok=True)
+            np.save(os.path.join(cc_dir, f'{detection_id}.npy'), correlations)
         picked_chans = chans[i]
         detect_stream = detect_streams_dict[detection_id]
         checksum, cccsum, used_chans = 0.0, 0.0, 0
@@ -403,7 +403,7 @@ def _prepare_data(family, detect_data, shift_len):
 def lag_calc(detections, detect_data, template_names, templates,
              shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
              vertical_chans=['Z'], cores=1, interpolate=False,
-             plot=False, plotdir=None, npy=False, npydir=None):
+             plot=False, plotdir=None, export_cc=False, cc_dir=None):
     """
     Cross-correlation derived picking of seismic events.
 
@@ -453,12 +453,12 @@ def lag_calc(detections, detect_data, template_names, templates,
         To generate a plot for every detection or not, defaults to False
     :param plotdir:
         Path to plotting folder, plots will be output here.
-    :type npy: bool
-    :param npy:
+    :type export_cc: bool
+    :param export_cc:
         To generate a binary file in NumPy for every detection or not,
         defaults to False
-    :type npydir: str
-    :param npydir:
+    :type cc_dir: str
+    :param cc_dir:
         Path to saving folder, NumPy files will be output here.
 
     :returns:
@@ -513,8 +513,8 @@ def lag_calc(detections, detect_data, template_names, templates,
         if the output[m] is for the same event as detections[n].
 
     .. note::
-        The correlation data that is saved to the binary files can be useful
-        for exploration on selecting proper threshold according to your data.
+        The correlation data that are saved to the binary files can be useful
+        to select an appropriate threshold for your data.
     """
     # First check that sample rates are equal for everything
     for tr in detect_data:
@@ -544,7 +544,7 @@ def lag_calc(detections, detect_data, template_names, templates,
                 min_cc=min_cc, horizontal_chans=horizontal_chans,
                 vertical_chans=vertical_chans, interpolate=interpolate,
                 cores=cores, shift_len=shift_len, plot=plot, plotdir=plotdir,
-                npy=npy, npydir=npydir)
+                export_cc=export_cc, cc_dir=cc_dir)
             initial_cat.update(template_dict)
     # Order the catalogue to match the input
     output_cat = Catalog()

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -190,7 +190,7 @@ def _concatenate_and_correlate(streams, template, cores):
 def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
                       horizontal_chans=['E', 'N', '1', '2'],
                       vertical_chans=['Z'], cores=1, interpolate=False,
-                      plot=False, plotdir=None):
+                      plot=False, plotdir=None, npy=False, npydir=None):
     """
     Compute cross-correlation picks for detections in a family.
 
@@ -227,6 +227,13 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
     :type plotdir: str
     :param plotdir:
         Path to plotting folder, plots will be output here.
+    :type npy: bool
+    :param npy:
+        To generate a binary file in NumPy for every detection or not,
+        defaults to False
+    :type npydir: str
+    :param npydir:
+        Path to saving folder, NumPy files will be output here.
 
     :return: Dictionary of picked events keyed by detection id.
     """
@@ -250,6 +257,8 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
     for i, detection_id in enumerate(detection_ids):
         detection = [d for d in family.detections if d.id == detection_id][0]
         correlations = ccc[i]
+        if npy:
+            np.save(os.path.join(npydir, detection_id+'.npy'), correlations)
         picked_chans = chans[i]
         detect_stream = detect_streams_dict[detection_id]
         checksum, cccsum, used_chans = 0.0, 0.0, 0
@@ -393,7 +402,7 @@ def _prepare_data(family, detect_data, shift_len):
 def lag_calc(detections, detect_data, template_names, templates,
              shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
              vertical_chans=['Z'], cores=1, interpolate=False,
-             plot=False, plotdir=None):
+             plot=False, plotdir=None, npy=False, npydir=None):
     """
     Cross-correlation derived picking of seismic events.
 
@@ -443,6 +452,13 @@ def lag_calc(detections, detect_data, template_names, templates,
         To generate a plot for every detection or not, defaults to False
     :param plotdir:
         Path to plotting folder, plots will be output here.
+    :type npy: bool
+    :param npy:
+        To generate a binary file in NumPy for every detection or not,
+        defaults to False
+    :type npydir: str
+    :param npydir:
+        Path to saving folder, NumPy files will be output here.
 
     :returns:
         Catalog of events with picks.  No origin information is included.
@@ -494,6 +510,10 @@ def lag_calc(detections, detect_data, template_names, templates,
             detections[n].id == output[m].resource_id
 
         if the output[m] is for the same event as detections[n].
+
+    .. note::
+        The correlation data that is saved to the binary files can be usefull
+        for exploration on selecting proper threshold according to your data.
     """
     # First check that sample rates are equal for everything
     for tr in detect_data:
@@ -522,7 +542,8 @@ def lag_calc(detections, detect_data, template_names, templates,
                 family=family, stream=detect_data,
                 min_cc=min_cc, horizontal_chans=horizontal_chans,
                 vertical_chans=vertical_chans, interpolate=interpolate,
-                cores=cores, shift_len=shift_len, plot=plot, plotdir=plotdir)
+                cores=cores, shift_len=shift_len, plot=plot, plotdir=plotdir,
+                npy=npy, npydir=npydir)
             initial_cat.update(template_dict)
     # Order the catalogue to match the input
     output_cat = Catalog()

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -512,7 +512,7 @@ def lag_calc(detections, detect_data, template_names, templates,
         if the output[m] is for the same event as detections[n].
 
     .. note::
-        The correlation data that is saved to the binary files can be usefull
+        The correlation data that is saved to the binary files can be useful
         for exploration on selecting proper threshold according to your data.
     """
     # First check that sample rates are equal for everything

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -261,7 +261,7 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
             os.makedirs(cc_dir, exist_ok=True)
             fname = f"{detection_id}-cc.npy"
             np.save(os.path.join(cc_dir, f'{fname}'), correlations)
-            Logger.info(f"Saved correlation statistic to {fname} (phase-picking)")
+            Logger.info(f"Saved correlation statistic to {fname} (lag_calc)")
         picked_chans = chans[i]
         detect_stream = detect_streams_dict[detection_id]
         checksum, cccsum, used_chans = 0.0, 0.0, 0

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -258,6 +258,7 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
         detection = [d for d in family.detections if d.id == detection_id][0]
         correlations = ccc[i]
         if npy:
+            os.makedirs(npydir, exist_ok=True)
             np.save(os.path.join(npydir, detection_id+'.npy'), correlations)
         picked_chans = chans[i]
         detect_stream = detect_streams_dict[detection_id]

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -259,7 +259,9 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
         correlations = ccc[i]
         if export_cc:
             os.makedirs(cc_dir, exist_ok=True)
-            np.save(os.path.join(cc_dir, f'{detection_id}.npy'), correlations)
+            fname = f"{detection_id}-cc.npy"
+            np.save(os.path.join(cc_dir, f'{fname}'), correlations)
+            Logger.info(f"Saved correlation statistic to {fname} (phase-picking)")
         picked_chans = chans[i]
         detect_stream = detect_streams_dict[detection_id]
         checksum, cccsum, used_chans = 0.0, 0.0, 0

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -503,8 +503,8 @@ class Family(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, plotdir=None,
-                 parallel=True, process_cores=None, ignore_length=False,
-                 ignore_bad_data=False, **kwargs):
+                 npy=False, npydir=None, parallel=True, process_cores=None,
+                 ignore_length=False, ignore_bad_data=False, **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -547,6 +547,13 @@ class Family(object):
         :param plotdir:
             The path to save plots to. If `plotdir=None` (default) then the
             figure will be shown on screen.
+        :type npy: bool
+        :param npy:
+            To generate a binary file in NumPy for every detection or not,
+            defaults to False
+        :type npydir: str
+        :param npydir:
+            Path to saving folder, NumPy files will be output here.
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
         :type process_cores: int
@@ -596,7 +603,8 @@ class Family(object):
             family=self, stream=processed_stream, shift_len=shift_len,
             min_cc=min_cc, horizontal_chans=horizontal_chans,
             vertical_chans=vertical_chans, cores=cores,
-            interpolate=interpolate, plot=plot, plotdir=plotdir)
+            interpolate=interpolate, plot=plot, plotdir=plotdir,
+            npy=npy, npydir=npydir)
         catalog_out = Catalog([ev for ev in picked_dict.values()])
         for detection_id, event in picked_dict.items():
             for pick in event.picks:

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -503,8 +503,9 @@ class Family(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, plotdir=None,
-                 npy=False, npydir=None, parallel=True, process_cores=None,
-                 ignore_length=False, ignore_bad_data=False, **kwargs):
+                 parallel=True, process_cores=None, ignore_length=False,
+                 ignore_bad_data=False, export_cc=False, cc_dir=None,
+                 **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -547,13 +548,6 @@ class Family(object):
         :param plotdir:
             The path to save plots to. If `plotdir=None` (default) then the
             figure will be shown on screen.
-        :type npy: bool
-        :param npy:
-            To generate a binary file in NumPy for every detection or not,
-            defaults to False
-        :type npydir: str
-        :param npydir:
-            Path to saving folder, NumPy files will be output here.
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
         :type process_cores: int
@@ -571,6 +565,13 @@ class Family(object):
             If False (default), errors will be raised if data are excessively
             gappy or are mostly zeros. If True then no error will be raised,
             but an empty trace will be returned (and not used in detection).
+        :type export_cc: bool
+        :param export_cc:
+            To generate a binary file in NumPy for every detection or not,
+            defaults to False
+        :type cc_dir: str
+        :param cc_dir:
+            Path to saving folder, NumPy files will be output here.
 
         :returns:
             Catalog of events with picks.  No origin information is included.
@@ -604,7 +605,7 @@ class Family(object):
             min_cc=min_cc, horizontal_chans=horizontal_chans,
             vertical_chans=vertical_chans, cores=cores,
             interpolate=interpolate, plot=plot, plotdir=plotdir,
-            npy=npy, npydir=npydir)
+            export_cc=export_cc, cc_dir=cc_dir)
         catalog_out = Catalog([ev for ev in picked_dict.values()])
         for detection_id, event in picked_dict.items():
             for pick in event.picks:

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -782,8 +782,8 @@ class Party(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, plotdir=None,
-                 parallel=True, process_cores=None, ignore_length=False,
-                 ignore_bad_data=False, **kwargs):
+                 npy=False, npydir=None, parallel=True, process_cores=None,
+                 ignore_length=False, ignore_bad_data=False, **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -826,6 +826,13 @@ class Party(object):
         :param plotdir:
             The path to save plots to. If `plotdir=None` (default) then the
             figure will be shown on screen.
+        :type npy: bool
+        :param npy:
+            To generate a binary file in NumPy for every detection or not,
+            defaults to False
+        :type npydir: str
+        :param npydir:
+            Path to saving folder, NumPy files will be output here.
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
         :type process_cores: int
@@ -898,6 +905,7 @@ class Party(object):
                     horizontal_chans=horizontal_chans,
                     vertical_chans=vertical_chans, cores=cores,
                     interpolate=interpolate, plot=plot, plotdir=plotdir,
+                    npy=npy, npydir=npydir,
                     parallel=parallel, process_cores=process_cores,
                     ignore_bad_data=ignore_bad_data,
                     ignore_length=ignore_length, **kwargs)

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -782,8 +782,9 @@ class Party(object):
     def lag_calc(self, stream, pre_processed, shift_len=0.2, min_cc=0.4,
                  horizontal_chans=['E', 'N', '1', '2'], vertical_chans=['Z'],
                  cores=1, interpolate=False, plot=False, plotdir=None,
-                 npy=False, npydir=None, parallel=True, process_cores=None,
-                 ignore_length=False, ignore_bad_data=False, **kwargs):
+                 parallel=True, process_cores=None, ignore_length=False,
+                 ignore_bad_data=False, export_cc=False, cc_dir=None,
+                 **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -826,12 +827,12 @@ class Party(object):
         :param plotdir:
             The path to save plots to. If `plotdir=None` (default) then the
             figure will be shown on screen.
-        :type npy: bool
-        :param npy:
+        :type export_cc: bool
+        :param export_cc:
             To generate a binary file in NumPy for every detection or not,
             defaults to False
-        :type npydir: str
-        :param npydir:
+        :type cc_dir: str
+        :param cc_dir:
             Path to saving folder, NumPy files will be output here.
         :type parallel: bool
         :param parallel: Turn parallel processing on or off.
@@ -905,7 +906,7 @@ class Party(object):
                     horizontal_chans=horizontal_chans,
                     vertical_chans=vertical_chans, cores=cores,
                     interpolate=interpolate, plot=plot, plotdir=plotdir,
-                    npy=npy, npydir=npydir,
+                    export_cc=export_cc, cc_dir=cc_dir,
                     parallel=parallel, process_cores=process_cores,
                     ignore_bad_data=ignore_bad_data,
                     ignore_length=ignore_length, **kwargs)

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -112,7 +112,8 @@ class SyntheticTests(unittest.TestCase):
 
     def test_family_picking(self):
         catalog_dict = xcorr_pick_family(
-            family=self.party[0], stream=self.data, shift_len=0.2, plot=False)
+            family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
+            npy=False)
         for event in catalog_dict.values():
             self.assertEqual(len(event.picks), len(self.data))
             for pick in event.picks:
@@ -134,7 +135,8 @@ class SyntheticTests(unittest.TestCase):
         gappy_data[0].data = np.ma.masked_array(
             data=gappy_data[0].data, mask=mask)
         catalog_dict = xcorr_pick_family(
-            family=self.party[0], stream=gappy_data, shift_len=0.2, plot=False)
+            family=self.party[0], stream=gappy_data, shift_len=0.2, plot=False,
+            npy=False)
         gap = gappy_data.split().get_gaps()
         for event in catalog_dict.values():
             if len(event.picks) != len(self.data):
@@ -153,7 +155,7 @@ class SyntheticTests(unittest.TestCase):
     def test_family_picking_with_interpolation(self):
         catalog_dict = xcorr_pick_family(
             family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
-            interpolate=True)
+            interpolate=True, npy=False)
         for event in catalog_dict.values():
             for pick in event.picks:
                 self.assertTrue("cc_max=" in pick.comments[0].text)
@@ -168,7 +170,7 @@ class SyntheticTests(unittest.TestCase):
             detections, self.data, template_names, templates,
             shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
             vertical_chans=['Z'], cores=1, interpolate=False,
-            plot=False)
+            plot=False, npy=False)
         self.assertEqual(len(output_cat), len(detections))
         for event in output_cat:
             self.assertEqual(len(event.picks), len(self.data))

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -113,7 +113,7 @@ class SyntheticTests(unittest.TestCase):
     def test_family_picking(self):
         catalog_dict = xcorr_pick_family(
             family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
-            npy=False)
+            export_cc=False)
         for event in catalog_dict.values():
             self.assertEqual(len(event.picks), len(self.data))
             for pick in event.picks:
@@ -136,7 +136,7 @@ class SyntheticTests(unittest.TestCase):
             data=gappy_data[0].data, mask=mask)
         catalog_dict = xcorr_pick_family(
             family=self.party[0], stream=gappy_data, shift_len=0.2, plot=False,
-            npy=False)
+            export_cc=False)
         gap = gappy_data.split().get_gaps()
         for event in catalog_dict.values():
             if len(event.picks) != len(self.data):
@@ -155,7 +155,7 @@ class SyntheticTests(unittest.TestCase):
     def test_family_picking_with_interpolation(self):
         catalog_dict = xcorr_pick_family(
             family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
-            interpolate=True, npy=False)
+            interpolate=True, export_cc=False)
         for event in catalog_dict.values():
             for pick in event.picks:
                 self.assertTrue("cc_max=" in pick.comments[0].text)
@@ -170,7 +170,7 @@ class SyntheticTests(unittest.TestCase):
             detections, self.data, template_names, templates,
             shift_len=0.2, min_cc=0.4, horizontal_chans=['E', 'N', '1', '2'],
             vertical_chans=['Z'], cores=1, interpolate=False,
-            plot=False, npy=False)
+            plot=False, export_cc=False)
         self.assertEqual(len(output_cat), len(detections))
         for event in output_cat:
             self.assertEqual(len(event.picks), len(self.data))

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -1,6 +1,8 @@
 """
 A series of test functions for the core functions in EQcorrscan.
 """
+import glob
+import os
 import unittest
 import numpy as np
 import logging
@@ -174,6 +176,15 @@ class SyntheticTests(unittest.TestCase):
         self.assertEqual(len(output_cat), len(detections))
         for event in output_cat:
             self.assertEqual(len(event.picks), len(self.data))
+
+    def test_xcorr_pick_family_export_cc(self):
+        cc_dir = 'cc_exported'
+        xcorr_pick_family(
+            family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
+            interpolate=False, export_cc=True, cc_dir=cc_dir)
+        cc_files = glob.glob(os.path.join(cc_dir, '*.npy'))
+        for fcc in cc_files:
+            np.load(fcc)
 
 
 class SimpleRealDataTests(unittest.TestCase):

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -183,6 +183,7 @@ class SyntheticTests(unittest.TestCase):
             family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
             interpolate=False, export_cc=True, cc_dir=cc_dir)
         cc_files = glob.glob(os.path.join(cc_dir, '*.npy'))
+        assert len(cc_files) == len(self.party[0])
         for fcc in cc_files:
             np.load(fcc)
 


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?
Added the ability of saving correlation data of the lag_calc as NumPy binary files.
It can be useful for exploration on selecting proper threshold according to data that used.
### Why was it initiated?  Any relevant Issues?

### PR Checklist
- [x] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
