### PR TITLE
add python version to conda env creation

### DIFF
--- a/eqcorrscan/doc/installation.rst
+++ b/eqcorrscan/doc/installation.rst
@@ -20,7 +20,7 @@ with the following:
 
 .. code-block:: bash
 
-    conda create -n eqcorrscan -c conda-forge colorama numpy scipy matplotlib obspy bottleneck pyproj
+    conda create -n eqcorrscan -c conda-forge colorama numpy scipy matplotlib obspy bottleneck pyproj python=3.8
     source activate eqcorrscan
 
 To then install EQcorrscan you can simply run:


### PR DESCRIPTION
### What does this PR do?
This PR adds a python version to the command to create a conda environment in the installation doc. 

### Why was it initiated?  Any relevant Issues?
Default behavior initiates a conda environment with Python 3.9, which yields a conflict when installing EQcorrscan via conda with `conda install -c conda-forge eqcorrscan`:
```
UnsatisfiableError: The following specifications were found
to be incompatible with the existing python installation in your environment:

Specifications:

  - eqcorrscan -> python[version='2.7.*|3.5.*|3.6.*|>=2.7,<2.8.0a0|>=3.6,<3.7.0a0|>=3.7,<3.8.0a0|>=3.8,<3.9.0a0|>=3.5,<3.6.0a0']

Your python: python=3.9
```

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [N/A] Any new features or fixed regressions are be covered via new tests.
- [N/A] Any new or changed features have are fully documented.
- [N/A] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
