### PR TITLE
Fix relative mag s picks

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,9 @@
  - Only full correlation stacks are returned now (e.g. where fewer than than
    the full number of channels are in the stack at the end of the stack, zeros
    are returned).
+* utils.mag_calc.relative_magnitude
+ - fixed bug where S-picks / traces were used for relative-magnitude calculation
+   against user's choice.
 
 ## 0.4.3
 * core.match_filter

--- a/eqcorrscan/tests/mag_calc_test.py
+++ b/eqcorrscan/tests/mag_calc_test.py
@@ -272,6 +272,27 @@ class TestRelativeAmplitudes(unittest.TestCase):
             correlations={tr.id: 0.2 for tr in self.st1})
         self.assertEqual(len(relative_magnitudes), 0)
 
+    def test_real_near_repeat_magnitudes_S_picks(self):
+        self.event1.picks.append(self.event1.picks[0].copy())
+        self.event1.picks[-1].phase_hint = "S"
+        self.event1.picks[-1].waveform_id.channel_code = "EHN"
+        self.st1.append(self.st1[0].copy())
+        self.st1[-1].id = self.st1[-1].id[0:-1] + "N"
+        self.event2.picks.append(self.event2.picks[13].copy())
+        self.event2.picks[-1].phase_hint = "S"
+        self.event2.picks[-1].waveform_id.channel_code = "EHN"
+        self.st2.append(
+            self.st2.select(station=self.st1[0].stats.station)[0].copy())
+        self.st2[-1].id = self.st2[-1].id[0:-1] + "N"
+        # Check that the results are not equal when using or not using S:
+        relative_magnitudes1 = relative_magnitude(
+            st1=self.st1, st2=self.st2, event1=self.event1, event2=self.event2,
+            use_s_picks=False)
+        relative_magnitudes2 = relative_magnitude(
+            st1=self.st1, st2=self.st2, event1=self.event1, event2=self.event2,
+            use_s_picks=True)
+        self.assertNotEqual(relative_magnitudes1, relative_magnitudes2)
+
 
 class TestAmpPickEvent(unittest.TestCase):
     @classmethod

--- a/eqcorrscan/utils/plotting.py
+++ b/eqcorrscan/utils/plotting.py
@@ -70,7 +70,7 @@ def _finalise_figure(fig, **kwargs):  # pragma: no cover
     show = kwargs.get("show", True)
     save = kwargs.get("save", False)
     savefile = kwargs.get("savefile", "EQcorrscan_figure.png")
-    return_fig = kwargs.get("return_figure", False)
+    return_figure = kwargs.get("return_figure", False)
     size = kwargs.get("size", (10.5, 7.5))
     fig.set_size_inches(size)
     if title:
@@ -80,7 +80,7 @@ def _finalise_figure(fig, **kwargs):  # pragma: no cover
         Logger.info("Saved figure to {0}".format(savefile))
     if show:
         plt.show(block=True)
-    if return_fig:
+    if return_figure:
         return fig
     fig.clf()
     plt.close(fig)


### PR DESCRIPTION
### What does this PR do?
Fix bug reported in #476 
@darren-tpk you could try this with your specific case if you'd like.

This fixes the bug related to using S-pick traces when these should be excluded. The solution includes that `_get_pick_for_station` in addition to the station code compares the channel code and that the traces only linked to S-picks are excluded at the beginning of the `relative_magnitude` function.

Two thoughts:

- do we have to accomodate that users may ever supply picks without channel specification (I think no)?
- is it confusing that the function `_get_pick_for_station` checks both station and channel code now, considering its name?

### PR Checklist
- [X] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).: PR is related to linked issue
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- ~~[ ] Any new or changed features have are fully documented.~~
- [X] Significant changes have been added to `CHANGES.md`.
- ~~[ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
