### PR TITLE
Check full SEED ID when comparing picks and waveforms

### DIFF
--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -511,7 +511,7 @@ class Family(object):
                  cores=1, interpolate=False, plot=False, plotdir=None,
                  parallel=True, process_cores=None, ignore_length=False,
                  ignore_bad_data=False, export_cc=False, cc_dir=None,
-                 **kwargs):
+                 check_full_seed=False, **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -584,6 +584,12 @@ class Family(object):
         :type cc_dir: str
         :param cc_dir:
             Path to saving folder, NumPy files will be output here.
+        :type check_full_seed: bool
+        :param check_full_seed:
+            If True, will check for duplicate traces against the full SEED id,
+            including Network, Station, Location and Channel. If False (default),
+            will check only against Station and Channel.
+
 
         :returns:
             Catalog of events with picks.  No origin information is included.
@@ -618,7 +624,7 @@ class Family(object):
             min_cc_from_mean_cc_factor=min_cc_from_mean_cc_factor,
             vertical_chans=vertical_chans, cores=cores,
             interpolate=interpolate, plot=plot, plotdir=plotdir,
-            export_cc=export_cc, cc_dir=cc_dir)
+            export_cc=export_cc, cc_dir=cc_dir, check_full_seed=check_full_seed)
         catalog_out = Catalog([ev for ev in picked_dict.values()])
         for detection_id, event in picked_dict.items():
             for pick in event.picks:

--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -838,7 +838,7 @@ class Party(object):
                  cores=1, interpolate=False, plot=False, plotdir=None,
                  parallel=True, process_cores=None, ignore_length=False,
                  ignore_bad_data=False, export_cc=False, cc_dir=None,
-                 **kwargs):
+                 check_full_seed=False, **kwargs):
         """
         Compute picks based on cross-correlation alignment.
 
@@ -911,6 +911,13 @@ class Party(object):
             If False (default), errors will be raised if data are excessively
             gappy or are mostly zeros. If True then no error will be raised,
             but an empty trace will be returned (and not used in detection).
+        :type check_full_seed: bool
+        :param check_full_seed:
+            If True, will check for duplicate traces against the full SEED id,
+            including Network, Station, Location and Channel. If False (default),
+            will check only against Station and Channel. This behavior was
+            originally necessary to cope with some software (i.e. SEISAN) not
+            storing picks with full SEED info.
 
         :returns:
             Catalog of events with picks.  No origin information is included.
@@ -970,7 +977,8 @@ class Party(object):
                     export_cc=export_cc, cc_dir=cc_dir,
                     parallel=parallel, process_cores=process_cores,
                     ignore_bad_data=ignore_bad_data,
-                    ignore_length=ignore_length, **kwargs)
+                    ignore_length=ignore_length,
+                    check_full_seed=check_full_seed, **kwargs)
         return catalog
 
     @staticmethod

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -723,11 +723,25 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     starttimes = []
     for _swin in swin:
         for tr in st:
-            starttime = {'station': tr.stats.station,
-                         'channel': tr.stats.channel, 'picks': []}
-            station_picks = [pick for pick in picks_copy
-                             if pick.waveform_id.station_code ==
-                             tr.stats.station]
+            if check_full_seed:
+                starttime = {'network': tr.stats.network,
+                             'station': tr.stats.station,
+                             'location': tr.stats.location,
+                             'channel': tr.stats.channel,
+                             'picks': []}
+                station_picks = [pick for pick in picks_copy
+                                 if pick.waveform_id.network_code ==
+                                 tr.stats.network and
+                                 pick.waveform_id.station_code ==
+                                 tr.stats.station and
+                                 pick.waveform_id.location_code ==
+                                 tr.stats.location]
+            else:
+                starttime = {'station': tr.stats.station,
+                             'channel': tr.stats.channel, 'picks': []}
+                station_picks = [pick for pick in picks_copy
+                                 if pick.waveform_id.station_code ==
+                                 tr.stats.station]
             if _swin == 'P_all':
                 p_pick = [pick for pick in station_picks
                           if pick.phase_hint.upper()[0] == 'P']

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -744,6 +744,10 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                                  pick.waveform_id.location_code ==
                                  tr.stats.location]
             else:
+                Logger.warning(
+                    'Not checking full SEED id compatibility between' +
+                    ' picks and waveforms. Checking full net.sta.loc.chan ' +
+                    'compatibility will be default behavior in future release')
                 starttime = {'station': tr.stats.station,
                              'channel': tr.stats.channel, 'picks': []}
                 station_picks = [pick for pick in picks_copy

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -807,8 +807,15 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
     for _starttime in starttimes:
         Logger.info(f"Working on channel {_starttime['station']}."
                     f"{_starttime['channel']}")
-        tr = st.select(
-            station=_starttime['station'], channel=_starttime['channel'])[0]
+        if check_full_seed:
+            tr = st.select(
+                network=_starttime['network'],
+                station=_starttime['station'],
+                location=_starttime['location'],
+                channel=_starttime['channel'])[0]
+        else:
+            tr = st.select(
+                station=_starttime['station'], channel=_starttime['channel'])[0]
         Logger.info(f"Found Trace {tr}")
         used_tr = False
         for pick in _starttime['picks']:

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -56,7 +56,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
                  all_horiz=False, delayed=True, plot=False, plotdir=None,
                  return_event=False, min_snr=None, parallel=False,
                  num_cores=False, save_progress=False, skip_short_chans=False,
-                 **kwargs):
+                 check_full_seed=False, **kwargs):
     """
     Generate processed and cut waveforms for use as templates.
 
@@ -120,6 +120,13 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
         Whether to ignore channels that have insufficient length data or not.
         Useful when the quality of data is not known, e.g. when downloading
         old, possibly triggered data from a datacentre
+    :type check_full_seed: bool
+    :param check_full_seed:
+        If True, will check the trace header against the full SEED id,
+        including Network, Station, Location and Channel. If False (default),
+        will check only against Station and Channel. This behavior was
+        originally necessary to cope with some software (i.e. SEISAN) not
+        storing picks with full SEED info.
 
     :returns: List of :class:`obspy.core.stream.Stream` Templates
     :rtype: list
@@ -399,7 +406,7 @@ def template_gen(method, lowcut, highcut, samp_rate, filt_order,
             template = _template_gen(
                 event.picks, st, length, swin, prepick=prepick, plot=plot,
                 all_horiz=all_horiz, delayed=delayed, min_snr=min_snr,
-                plotdir=plotdir)
+                plotdir=plotdir, check_full_seed=check_full_seed)
             process_lengths.append(len(st[0].data) / samp_rate)
             temp_list.append(template)
             catalog_out += event

--- a/eqcorrscan/utils/catalog_to_dd.py
+++ b/eqcorrscan/utils/catalog_to_dd.py
@@ -413,8 +413,8 @@ def _make_event_pair(sparse_event, master, event_id_mapper, min_link):
                 master_pick.phase_hint not in "PS":  # pragma: no cover
             continue
         matched_picks = [p for p in sparse_event.picks
-                         if p.station == master_pick.station
-                         and p.phase_hint == master_pick.phase_hint]
+                         if p.seed_id == master_pick.seed_id
+                         and p.phase == master_pick.phase]
         for matched_pick in matched_picks:
             differential_times.obs.append(
                 _DTObs(station=master_pick.station,

--- a/eqcorrscan/utils/catalog_to_dd.py
+++ b/eqcorrscan/utils/catalog_to_dd.py
@@ -401,7 +401,8 @@ def _compute_dt(sparse_catalog, master, min_link, event_id_mapper):
         min_link=min_link) for event in sparse_catalog]
 
 
-def _make_event_pair(sparse_event, master, event_id_mapper, min_link):
+def _make_event_pair(sparse_event, master, event_id_mapper, min_link,
+                     check_full_seed=False):
     """
     Make an event pair for a given event and master event.
     """
@@ -412,9 +413,14 @@ def _make_event_pair(sparse_event, master, event_id_mapper, min_link):
         if master_pick.phase_hint and \
                 master_pick.phase_hint not in "PS":  # pragma: no cover
             continue
-        matched_picks = [p for p in sparse_event.picks
-                         if p.seed_id == master_pick.seed_id
-                         and p.phase == master_pick.phase]
+        if check_full_seed:
+            matched_picks = [p for p in sparse_event.picks
+                             if p.seed_id == master_pick.seed_id
+                             and p.phase == master_pick.phase]
+        else:
+            matched_picks = [p for p in sparse_event.picks
+                             if p.station == master_pick.station
+                             and p.phase == master_pick.phase]
         for matched_pick in matched_picks:
             differential_times.obs.append(
                 _DTObs(station=master_pick.station,


### PR DESCRIPTION
### What does this PR do?

Clean take-over from #391 

Uses full SEED information (adds network and location) when comparing e.g. pick.waveform_id and tr.stats in a number of functions. Mostly importantly template_gen, but may also include mag_calc and others. 

### Why was it initiated?  Any relevant Issues?
 #388 

In situations where the desired template or trace contains unique picks with the same Station and Channel, but different location and/or Network codes (e.g. separate sensors in one borehole), current behavior does not differentiate between them.

### Assorted to-dos:
- [ ] `utils.correlate` funcs all return `cccs`, `no_chans`, and `chans`. `chans` only includes station.channel, which then gets passed to `Detection` objects. Allow for full seed chans in `Detection`
- [ ] Track down all the possible effects of using a full seed id `chans` attribute for `Detection` objects...could touch quite a lot...
- [ ] Lag calc `UsedChannel` only uses station.channel. Allow for full seed option.

### PR Checklist
- [ ] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
