### PR TITLE
Bump obspy version to 1.3.0

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -7,12 +7,12 @@ dependencies:
   - matplotlib>=1.3.0
   - scipy>=0.18
   - mock
-  - obspy>=1.0.3
+  - obspy>=1.3.0
   - h5py
   - pyyaml
   - bottleneck
   - fftw
-  - pyfftw>=0.12.0
+  - pyfftw==0.12.0
   - pyproj<2
   - pytest>=2.0.0
   - pytest-cov

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -12,7 +12,6 @@ dependencies:
   - pyyaml
   - bottleneck
   - fftw
-  - pyproj<2
   - pytest>=2.0.0
   - pytest-cov
   - pytest-pep8

--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -12,7 +12,6 @@ dependencies:
   - pyyaml
   - bottleneck
   - fftw
-  - pyfftw==0.12.0
   - pyproj<2
   - pytest>=2.0.0
   - pytest-cov
@@ -21,3 +20,6 @@ dependencies:
   - pytest-rerunfailures
   - pytest-mpl
   - codecov
+  - pip
+  - pip:
+    - pyfftw

--- a/.github/test_conda_env_macOS.yml
+++ b/.github/test_conda_env_macOS.yml
@@ -16,8 +16,8 @@ dependencies:
   - matplotlib>=1.3.0
   - scipy>=0.18
   - mock
-  - obspy>=1.0.3
-  - h5py
+  - obspy>=1.3.0
+  - h5py<3.2  # Issue with dep resolution: https://github.com/conda-forge/h5py-feedstock/issues/92
   - pyyaml
   - bottleneck
   - fftw

--- a/.github/test_conda_env_macOS.yml
+++ b/.github/test_conda_env_macOS.yml
@@ -21,8 +21,6 @@ dependencies:
   - pyyaml
   - bottleneck
   - fftw
-  - pyfftw>=0.12.0
-  - pyproj<2
   - pytest>=2.0.0
   - pytest-cov
   - pytest-pep8
@@ -30,3 +28,6 @@ dependencies:
   - pytest-rerunfailures
   - pytest-mpl
   - codecov
+  - pip
+  - pip:
+    - pyfftw

--- a/.github/test_condarc.yml
+++ b/.github/test_condarc.yml
@@ -1,0 +1,4 @@
+channels:
+  - conda-forge
+  - defaults
+auto_activate_base: false

--- a/.github/test_condarc.yml
+++ b/.github/test_condarc.yml
@@ -1,4 +1,0 @@
-channels:
-  - conda-forge
-  - defaults
-auto_activate_base: false

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -22,26 +22,13 @@ jobs:
               cp .github/test_conda_env_macOS.yml .github/test_conda_env.yml
           fi
 
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if needed by env file has not changed
-          CACHE_NUMBER: 0
+      - name: Setup micromamba
+        uses: mamba-org/provision-with-micromamba@main
         with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('.github/test_conda_env.yml') }}
-
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          miniconda-version: 'latest'
-          python-version: ${{ matrix.python-version }}
-          activate-environment: eqcorrscan-test
+          environment-name: eqcorrscan-test
           environment-file: .github/test_conda_env.yml
-          condarc-file: .github/test_condarc.yml
-          use-only-tar-bz2: true  # Must be set for caching to work properly
+          cache-env: true
+          extra-specs: python=${{ matrix.python-version }}
 
       - name: install eqcorrscan
         shell: bash -l {0}

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -11,42 +11,42 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
 #      continue-on-error: true
-    env:
-      env_file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
-      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
-      prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\eqcorrscan-test' }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
+      - name: Get conda env file
+        shell: bash -l {0}
+        run: |
+          if [ "$RUNNER_OS" == "macOS"  ]; then
+              cp .github/test_conda_env_macOS.yml .github/test_conda_env.yml
+          fi
 
-      - uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: eqcorrscan-test
-          use-mamba: true
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ${{ env.prefix }}
-          key: ${{ env.cache_key }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+      - name: Cache conda
+        uses: actions/cache@v2
         env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          # Increase this value to reset cache if needed by env file has not changed
           CACHE_NUMBER: 0
-        id: cache
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('.github/test_conda_env.yml') }}
 
-      - name: Update environment
-        run: mamba env update -n eqcorrscan-test -f ${{ env.env_file }}
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: 'latest'
+          python-version: ${{ matrix.python-version }}
+          activate-environment: eqcorrscan-test
+          environment-file: .github/test_conda_env.yml
+          condarc-file: .github/test_condarc.yml
+          use-only-tar-bz2: true  # Must be set for caching to work properly
 
       - name: install eqcorrscan
         shell: bash -l {0}
         run: |
-          pip install -e . -v
+          pip install -e .
 
       - name: print package info
         shell: bash -l {0}
@@ -97,42 +97,35 @@ jobs:
       matrix:
         python-version: [3.8]
       fail-fast: false
-    env:
-      env_file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
-      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
-      prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\eqcorrscan-test' }}
+
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get current date
-        id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
-
-      - uses: conda-incubator/setup-miniconda@v2.1.1
-        with:
-          miniforge-variant: Mambaforge
-          miniforge-version: latest
-          activate-environment: eqcorrscan-test
-          use-mamba: true
-          python-version: ${{ matrix.python-version }}
-
-      - uses: actions/cache@v2
-        with:
-          path: ${{ env.prefix }}
-          key: ${{ env.cache_key }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+      - name: Cache conda
+        uses: actions/cache@v2
         env:
-          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          # Increase this value to reset cache if needed by env file has not changed
           CACHE_NUMBER: 0
-        id: cache
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+            hashFiles('.github/test_conda_env.yml') }}
 
-      - name: Update environment
-        run: mamba env update -n eqcorrscan-test -f ${{ env.env_file }}
-        if: steps.cache.outputs.cache-hit != 'true'
+      - name: Setup conda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          miniconda-version: 'latest'
+          python-version: ${{ matrix.python-version }}
+          activate-environment: eqcorrscan-test
+          environment-file: .github/test_conda_env.yml
+          condarc-file: .github/test_condarc.yml
+          use-only-tar-bz2: true  # Must be set for caching to work properly
 
       - name: install eqcorrscan
         shell: bash -l {0}
         run: |
-          pip install -e . -v
+          pip install -e .
 
       - name: print package info
         shell: bash -l {0}

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9, 3.10]
       fail-fast: false
 #      continue-on-error: true
 

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -46,7 +46,7 @@ jobs:
       - name: install eqcorrscan
         shell: bash -l {0}
         run: |
-          pip install -e .
+          pip install -e . -v
 
       - name: print package info
         shell: bash -l {0}
@@ -132,7 +132,7 @@ jobs:
       - name: install eqcorrscan
         shell: bash -l {0}
         run: |
-          pip install -e .
+          pip install -e . -v
 
       - name: print package info
         shell: bash -l {0}

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -11,24 +11,38 @@ jobs:
         python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
 #      continue-on-error: true
+    env:
+      env-file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
+      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
+      prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\eqcorrscan-test' }}
 
     steps:
       - uses: actions/checkout@v2
 
-      - name: Get conda env file
-        shell: bash -l {0}
-        run: |
-          if [ "$RUNNER_OS" == "macOS"  ]; then
-              cp .github/test_conda_env_macOS.yml .github/test_conda_env.yml
-          fi
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Setup micromamba
-        uses: mamba-org/provision-with-micromamba@main
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          environment-name: eqcorrscan-test
-          environment-file: .github/test_conda_env.yml
-          cache-env: true
-          extra-specs: python=${{ matrix.python-version }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          activate-environment: eqcorrscan-test
+          use-mamba: true
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.prefix }}
+          key: ${{ env.cache_key }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n eqcorrscan-test -f ${{ env.env_file }}
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: install eqcorrscan
         shell: bash -l {0}

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9']
       fail-fast: false
 #      continue-on-error: true
 

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -12,10 +12,9 @@ jobs:
       fail-fast: false
 #      continue-on-error: true
     env:
-      env-file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
+      env_file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
       cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
       prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\eqcorrscan-test' }}
-
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ['3.7', '3.8', '3.9', '3.10']
       fail-fast: false
 #      continue-on-error: true
 

--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -97,30 +97,37 @@ jobs:
       matrix:
         python-version: [3.8]
       fail-fast: false
-
+    env:
+      env_file: ${{ startsWith(matrix.os, 'macos') && '.github/test_conda_env_macOS.yml' || '.github/test_conda_env.yml' }}
+      cache_key: ${{ matrix.os }}-py${{ matrix.python-version }}
+      prefix: ${{ startsWith(matrix.os, 'ubuntu') && '/usr/share/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'macos') && '/Users/runner/miniconda3/envs/eqcorrscan-test' || startsWith(matrix.os, 'windows') && 'C:\Miniconda3\envs\eqcorrscan-test' }}
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          # Increase this value to reset cache if needed by env file has not changed
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('.github/test_conda_env.yml') }}
+      - name: Get current date
+        id: date
+        run: echo "::set-output name=date::$(date +'%Y-%m-%d')"
 
-      - name: Setup conda
-        uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v2.1.1
         with:
-          miniconda-version: 'latest'
-          python-version: ${{ matrix.python-version }}
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
           activate-environment: eqcorrscan-test
-          environment-file: .github/test_conda_env.yml
-          condarc-file: .github/test_condarc.yml
-          use-only-tar-bz2: true  # Must be set for caching to work properly
+          use-mamba: true
+          python-version: ${{ matrix.python-version }}
+
+      - uses: actions/cache@v2
+        with:
+          path: ${{ env.prefix }}
+          key: ${{ env.cache_key }}-hash${{ hashFiles(env.env_file) }}-${{ steps.date.outputs.date }}-${{ env.CACHE_NUMBER }}
+        env:
+          # Increase this value to reset cache if etc/example-environment.yml has not changed
+          CACHE_NUMBER: 0
+        id: cache
+
+      - name: Update environment
+        run: mamba env update -n eqcorrscan-test -f ${{ env.env_file }}
+        if: steps.cache.outputs.cache-hit != 'true'
 
       - name: install eqcorrscan
         shell: bash -l {0}

--- a/eqcorrscan/utils/clustering.py
+++ b/eqcorrscan/utils/clustering.py
@@ -837,21 +837,20 @@ def remove_unclustered(catalog, distance_cutoff, num_threads=None):
     """
     import ctypes
     from eqcorrscan.utils.libnames import _load_cdll
-    from future.utils import native_str
     from math import radians
 
     utilslib = _load_cdll('libutils')
 
     utilslib.remove_unclustered.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.uint8,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_float, ctypes.c_int]
     utilslib.remove_unclustered.restype = ctypes.c_int
 
@@ -905,20 +904,19 @@ def dist_mat_km(catalog, num_threads=None):
     """
     import ctypes
     from eqcorrscan.utils.libnames import _load_cdll
-    from future.utils import native_str
 
     utilslib = _load_cdll('libutils')
 
     utilslib.distance_matrix.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int]
     utilslib.distance_matrix.restype = ctypes.c_int
 

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -28,7 +28,6 @@ from multiprocessing.pool import ThreadPool
 
 import numpy as np
 import math
-from future.utils import native_str
 
 from eqcorrscan.utils.libnames import _load_cdll
 
@@ -452,13 +451,13 @@ def time_multi_normxcorr(templates, stream, pads, threaded=False, *args,
 
     argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int, ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     restype = ctypes.c_int
     if threaded:
         func = utilslib.multi_normxcorr_time_threaded
@@ -527,22 +526,22 @@ def fftw_normxcorr(templates, stream, pads, threaded=False, *args, **kwargs):
 
     argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long, ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.float32, ndim=1,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     restype = ctypes.c_int
 
     if threaded:
@@ -750,23 +749,23 @@ def fftw_multi_normxcorr(template_array, stream_array, pad_array, seed_ids,
 
     utilslib.multi_normxcorr_fftw.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long, ctypes.c_long, ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.float32,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long,
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.intc,
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int]
     utilslib.multi_normxcorr_fftw.restype = ctypes.c_int
     '''

--- a/eqcorrscan/utils/findpeaks.py
+++ b/eqcorrscan/utils/findpeaks.py
@@ -14,7 +14,6 @@ import numpy as np
 
 from multiprocessing import Pool, cpu_count
 from scipy import ndimage
-from future.utils import native_str
 
 from eqcorrscan.utils.correlate import pool_boy
 from eqcorrscan.utils.libnames import _load_cdll
@@ -344,17 +343,17 @@ def _multi_decluster(peaks, indices, trig_int, thresholds, cores):
 
     func.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(total_length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=long_type, shape=(total_length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=long_type, shape=(n,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(n,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         long_type,
         np.ctypeslib.ndpointer(dtype=np.uint32, shape=(total_length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int]
     func.restype = ctypes.c_int
 
@@ -440,14 +439,14 @@ def decluster_distance_time(peaks, index, trig_int, catalog,
 
     func.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=long_type, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length * length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         long_type, ctypes.c_float, long_type, ctypes.c_float,
         np.ctypeslib.ndpointer(dtype=np.uint32, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     func.restype = ctypes.c_int
 
     sorted_inds = np.abs(peaks).argsort()
@@ -505,12 +504,12 @@ def decluster(peaks, index, trig_int, threshold=0):
 
     func.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         np.ctypeslib.ndpointer(dtype=long_type, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         long_type, ctypes.c_float, long_type,
         np.ctypeslib.ndpointer(dtype=np.uint32, shape=(length,),
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     func.restype = ctypes.c_int
 
     sorted_inds = np.abs(peaks).argsort()
@@ -539,10 +538,10 @@ def _find_peaks_c(array, threshold):
     length = array.shape[0]
     utilslib.find_peaks.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length, ),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long, ctypes.c_float,
         np.ctypeslib.ndpointer(dtype=np.uint32, shape=(length, ),
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     utilslib.find_peaks.restype = ctypes.c_int
     arr = np.ascontiguousarray(array, np.float32)
     out = np.ascontiguousarray(np.zeros((length, ), dtype=np.uint32))
@@ -567,13 +566,13 @@ def _multi_find_peaks_c(arrays, thresholds, threads):
     arr = np.ascontiguousarray(arrays.flatten(), np.float32)
     utilslib.multi_find_peaks.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(n * length,),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_long, ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(n, ),
-                               flags=native_str('C_CONTIGUOUS')),
+                               flags='C_CONTIGUOUS'),
         ctypes.c_int,
         np.ctypeslib.ndpointer(dtype=np.uint32, shape=(n * length, ),
-                               flags=native_str('C_CONTIGUOUS'))]
+                               flags='C_CONTIGUOUS')]
     utilslib.multi_find_peaks.restype = ctypes.c_int
 
     out = np.ascontiguousarray(np.zeros((n * length, ), dtype=np.uint32))

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -632,7 +632,6 @@ def _resample(tr, sampling_rate, threads=1):
     Provide a pyfftw version of obspy's trace resampling.  This code is
     modified from obspy's Trace.resample method.
     """
-    from future.utils import native_str
     from scipy.signal import get_window
     from pyfftw.interfaces.scipy_fftpack import rfft, irfft
 
@@ -648,7 +647,7 @@ def _resample(tr, sampling_rate, threads=1):
     x_i = x[1::2]
 
     large_w = np.fft.ifftshift(
-        get_window(native_str("hanning"), tr.stats.npts))
+        get_window("hanning", tr.stats.npts))
     x_r *= large_w[:tr.stats.npts // 2 + 1]
     x_i *= large_w[:tr.stats.npts // 2 + 1]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib>=1.3.0
 scipy>=0.18
 bottleneck
 obspy>=1.3.0  # ObsPy <1.3.0 is incompatible with numpy >= 1.22: https://github.com/obspy/obspy/issues/2912
-pyfftw==0.12  # PyFFTW 0.13 on conda has a build issue: https://github.com/conda-forge/pyfftw-feedstock/issues/51
+pyfftw  # PyFFTW 0.13 on conda has a build issue: https://github.com/conda-forge/pyfftw-feedstock/issues/51
 h5py
 pytest>=2.0.0
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ matplotlib>=1.3.0
 scipy>=0.18
 bottleneck
 obspy>=1.3.0  # ObsPy <1.3.0 is incompatible with numpy >= 1.22: https://github.com/obspy/obspy/issues/2912
-pyfftw
+pyfftw==0.12  # PyFFTW 0.13 on conda has a build issue: https://github.com/conda-forge/pyfftw-feedstock/issues/51
 h5py
 pytest>=2.0.0
 pytest-cov

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.12
 matplotlib>=1.3.0
 scipy>=0.18
 bottleneck
-obspy>=1.0.3
+obspy>=1.3.0  # ObsPy <1.3.0 is incompatible with numpy >= 1.22: https://github.com/obspy/obspy/issues/2912
 pyfftw
 h5py
 pytest>=2.0.0


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Bumps minimum obspy verison to 1.3.0 to cope with numpy incompat: https://github.com/obspy/obspy/issues/2912

### Why was it initiated?  Any relevant Issues?

https://github.com/obspy/obspy/issues/2912

### PR Checklist
~~- [ ] `develop` base branch selected?~~
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~~- [ ] Any new features or fixed regressions are be covered via new tests.~~
~~- [ ] Any new or changed features have are fully documented.~~
~~- [ ] Significant changes have been added to `CHANGES.md`.~~
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
