### PR TITLE
Make CC-interpolation simpler & more robust

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Current
 * core.match_filter.tribe
  - Detect now allows passing of pre-processed data
+* core.lag_calc._xcorr_interp
+ - -CC-interpolation replaced with resampling (more robust)
 * utils.correlate
  - Fast Matched Filter now supported natively for version >= 1.4.0
  - Only full correlation stacks are returned now (e.g. where fewer than than

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,8 @@
 * core.match_filter.tribe
  - Detect now allows passing of pre-processed data
 * core.lag_calc._xcorr_interp
- - -CC-interpolation replaced with resampling (more robust)
+ - CC-interpolation replaced with resampling (more robust), old method
+   deprecated. Use new method with use_new_resamp_method=True as **kwarg.
 * utils.correlate
  - Fast Matched Filter now supported natively for version >= 1.4.0
  - Only full correlation stacks are returned now (e.g. where fewer than than

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -11,9 +11,7 @@ Functions to generate pick-corrections for events detected by correlation.
 import numpy as np
 import scipy
 import logging
-import warnings
 import os
-import scipy
 
 from collections import Counter, namedtuple
 

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -53,6 +53,8 @@ def _xcorr_interp(ccc, dt, resample_factor=10):
     :type ccc: numpy.ndarray
     :param dt: sample interval
     :type dt: float
+    :param resample_factor: Factor for upsampling CC-values.
+    :type resample_factor: int
 
     :return: Position of interpolated maximum in seconds from start of ccc
     :rtype: float

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -46,7 +46,8 @@ class LagCalcError(Exception):
         return 'LagCalcError: ' + self.value
 
 
-def _xcorr_interp(ccc, dt, resample_factor=10, use_new_resamp_method=False):
+def _xcorr_interp(ccc, dt, resample_factor=10, use_new_resamp_method=False,
+                  **kwargs):
     """
     Resample correlation-trace and check if there is a better CCC peak for
     sub-sample precision.
@@ -453,7 +454,7 @@ def lag_calc(detections, detect_data, template_names, templates,
              shift_len=0.2, min_cc=0.4, min_cc_from_mean_cc_factor=None,
              horizontal_chans=['E', 'N', '1', '2'],
              vertical_chans=['Z'], cores=1, interpolate=False,
-             plot=False, plotdir=None, export_cc=False, cc_dir=None):
+             plot=False, plotdir=None, export_cc=False, cc_dir=None, **kwargs):
     """
     Cross-correlation derived picking of seismic events.
 
@@ -600,7 +601,7 @@ def lag_calc(detections, detect_data, template_names, templates,
                 horizontal_chans=horizontal_chans,
                 vertical_chans=vertical_chans, interpolate=interpolate,
                 cores=cores, shift_len=shift_len, plot=plot, plotdir=plotdir,
-                export_cc=export_cc, cc_dir=cc_dir)
+                export_cc=export_cc, cc_dir=cc_dir, **kwargs)
             initial_cat.update(template_dict)
     # Order the catalogue to match the input
     output_cat = Catalog()

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -618,7 +618,7 @@ class Family(object):
             min_cc_from_mean_cc_factor=min_cc_from_mean_cc_factor,
             vertical_chans=vertical_chans, cores=cores,
             interpolate=interpolate, plot=plot, plotdir=plotdir,
-            export_cc=export_cc, cc_dir=cc_dir)
+            export_cc=export_cc, cc_dir=cc_dir, **kwargs)
         catalog_out = Catalog([ev for ev in picked_dict.values()])
         for detection_id, event in picked_dict.items():
             for pick in event.picks:

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -164,6 +164,16 @@ class SyntheticTests(unittest.TestCase):
                 self.assertAlmostEqual(
                     float(pick.comments[0].text.split("=")[-1]), 1.0, 1)
 
+    def test_family_picking_with_new_interpolation(self):
+        catalog_dict = xcorr_pick_family(
+            family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
+            interpolate=True, use_new_resamp_method=True, export_cc=False)
+        for event in catalog_dict.values():
+            for pick in event.picks:
+                self.assertTrue("cc_max=" in pick.comments[0].text)
+                self.assertAlmostEqual(
+                    float(pick.comments[0].text.split("=")[-1]), 1.0, 1)
+
     def test_lag_calc_api(self):
         detections = [d for f in self.party for d in f]
         templates = [f.template.st for f in self.party]
@@ -258,7 +268,7 @@ class ShortTests(unittest.TestCase):
                         0.60129057, -0.71043723,  0.16709118, 0.96839009,
                         1.58283915, -0.3053663])
 
-        _xcorr_interp(ccc, 0.1)
+        _xcorr_interp(ccc, 0.1, use_new_resamp_method=True)
         self.assertEqual(len(self.log_messages['warning']), 1)
         self.assertTrue(
             'not give an accurate result' in self.log_messages['warning'][0])

--- a/eqcorrscan/utils/catalog_to_dd.py
+++ b/eqcorrscan/utils/catalog_to_dd.py
@@ -540,6 +540,8 @@ def compute_differential_times(catalog, correlation, stream_dict=None,
         min_cc=min_cc, stream_dict=stream_dict, extract_len=extract_len,
         pre_pick=pre_pick, shift_len=shift_len, interpolate=interpolate,
         max_workers=max_workers)
+    for key, value in kwargs.items():
+        correlation_kwargs.update({key: value})
     if correlation:
         for arg, name in correlation_kwargs.items():
             assert arg is not None, "{0} is required for correlation".format(

--- a/eqcorrscan/utils/catalog_to_dd.py
+++ b/eqcorrscan/utils/catalog_to_dd.py
@@ -221,7 +221,7 @@ def _prepare_stream(stream, event, extract_len, pre_pick, seed_pick_ids=None):
 
 def _compute_dt_correlations(catalog, master, min_link, event_id_mapper,
                              stream_dict, min_cc, extract_len, pre_pick,
-                             shift_len, interpolate, max_workers=1):
+                             shift_len, interpolate, max_workers=1, **kwargs):
     """ Compute cross-correlation delay times. """
     max_workers = max_workers or 1
     Logger.info(
@@ -352,7 +352,8 @@ def _compute_dt_correlations(catalog, master, min_link, event_id_mapper,
                         continue
                     correlation = ccc_out[i][j]
                     if interpolate:
-                        shift, cc_max = _xcorr_interp(correlation, dt=delta)
+                        shift, cc_max = _xcorr_interp(correlation, dt=delta,
+                                                      **kwargs)
                     else:
                         cc_max = np.amax(correlation)
                         shift = np.argmax(correlation) * delta

--- a/setup.py
+++ b/setup.py
@@ -395,7 +395,9 @@ def setup_package():
         'tests_require': ['pytest>=2.0.0', 'pytest-cov', 'pytest-pep8',
                           'pytest-xdist', 'pytest-rerunfailures',
                           'obspy>=1.1.0'],
-        'cmdclass': {'build_ext': CustomBuildExt}
+        'cmdclass': {'build_ext': CustomBuildExt},
+        # Declare packages explicitly so setuptools>=61.0.0 does not auto discover
+        'packages': []
     }
 
     if using_setuptools:

--- a/setup.py
+++ b/setup.py
@@ -373,7 +373,8 @@ def setup_package():
     setup_args = {
         'name': 'EQcorrscan',
         'version': VERSION,
-        'description': 'EQcorrscan - matched-filter earthquake detection and analysis',
+        'description':
+        'EQcorrscan - matched-filter earthquake detection and analysis',
         'long_description': long_description,
         'url': 'https://github.com/eqcorrscan/EQcorrscan',
         'author': 'Calum Chamberlain',
@@ -396,7 +397,8 @@ def setup_package():
                           'pytest-xdist', 'pytest-rerunfailures',
                           'obspy>=1.1.0'],
         'cmdclass': {'build_ext': CustomBuildExt},
-        # Declare packages explicitly so setuptools>=61.0.0 does not auto discover
+        # Declare packages explicitly so setuptools>=61.0.0 does not auto
+        # discover
         'packages': []
     }
 


### PR DESCRIPTION
### What does this PR do?
Replaces the CC-interpolation function that can be used for `lag_calc` and `catalog_to_dd` with a function that simply resamples the CC.

### Why was it initiated?  Any relevant Issues?

- CC-interpolation with `_xcorr_interp` "failed" (i.e., no improvement with interpolation) more often than maybe necessary. For the example data in the test, the new function fails to produce an improved CC with interpolation in only about 90 cases, while the previous one failed in about 150 cases. 
- `_xcorr_interp` had one specific weakness: it needs more than 2 samples with negative curvature to interpolate around the peak of the CC. If seismograms are filtered just below the Nyquist frequency (e.g., sampling rate 20 Hz and low-pass filter at 9.9 Hz) and contain plenty of high-frequency content just below the Nyquist frequency, then that criterion of more than 2 samples with negative curvature is often not fulfilled [(c.f. these lines)](https://github.com/eqcorrscan/EQcorrscan/blob/6286e4ff2dbb073eb98379ea69390ff3841b0b09/eqcorrscan/core/lag_calc.py#L74-L78) 
- On a dataset where the above was quite relevant, the new function improved the dt-accuracy for about 15 % more correlations than the old function (n=8*10^7)

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~


