### PR TITLE
Include prepick in lag-calc data preparation.

### DIFF
--- a/.github/workflows/runtest.yml
+++ b/.github/workflows/runtest.yml
@@ -65,7 +65,7 @@ jobs:
       - name: run main test suite
         shell: bash -l {0}
         run: |
-          py.test -n 2 -m "not serial and not network and not superslow" --cov-report=xml
+          py.test -n 2 -m "not serial and not network and not superslow" --cov-report=xml --dist loadscope
 
       - name: run serial test
         if: always()

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -387,7 +387,7 @@ def _prepare_data(family, detect_data, shift_len):
         length = round(length_samples) / family.template.samp_rate
         Logger.info("Setting length to {0}s to give an integer number of "
                     "samples".format(length))
-    prepick = shift_len
+    prepick = shift_len + family.template.prepick
     detect_streams_dict = family.extract_streams(
         stream=detect_data, length=length, prepick=prepick)
     for key, detect_stream in detect_streams_dict.items():
@@ -557,7 +557,7 @@ def lag_calc(detections, detect_data, template_names, templates,
             detections=template_detections,
             template=Template(
                 name=template_name, st=template,
-                samp_rate=template[0].stats.sampling_rate))
+                samp_rate=template[0].stats.sampling_rate, prepick=0.0))
         # Make a sparse template
         if len(template_detections) > 0:
             template_dict = xcorr_pick_family(

--- a/eqcorrscan/tests/find_peaks_test.py
+++ b/eqcorrscan/tests/find_peaks_test.py
@@ -192,7 +192,7 @@ class TestEdgeCases:
         spike_locs = np.random.randint(0, self.data_len, size=500)
         threshold = 0.5
         for spike_loc in spike_locs:
-            arr[spike_loc] *= 100 * np.random.randn()
+            arr[spike_loc] *= 100 * np.random.random()
         return arr, spike_locs, threshold
 
     @pytest.fixture(scope='class')

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -78,9 +78,11 @@ class SyntheticTests(unittest.TestCase):
                 self.assertAlmostEqual(
                     tr.stats.endtime - tr.stats.starttime,
                     (2 * shift_len) + self.t_length, 1)
-                pick = [p for p in detection.event.picks if p.waveform_id.get_seed_string() == tr.id][0]
+                pick = [p for p in detection.event.picks
+                        if p.waveform_id.get_seed_string() == tr.id][0]
                 self.assertAlmostEqual(
-                    tr.stats.starttime, pick.time - (family.template.prepick + shift_len), 1)
+                    tr.stats.starttime,
+                    pick.time - (family.template.prepick + shift_len), 1)
 
     def test_prepare_data(self):
         shift_len = 0.2

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -78,6 +78,9 @@ class SyntheticTests(unittest.TestCase):
                 self.assertAlmostEqual(
                     tr.stats.endtime - tr.stats.starttime,
                     (2 * shift_len) + self.t_length, 1)
+                pick = [p for p in detection.event.picks if p.waveform_id.get_seed_string() == tr.id][0]
+                self.assertAlmostEqual(
+                    tr.stats.starttime, pick.time - (family.template.prepick + shift_len), 1)
 
     def test_prepare_data(self):
         shift_len = 0.2

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -3,10 +3,12 @@ A series of test functions for the core functions in EQcorrscan.
 """
 import glob
 import os
+import shutil
 import unittest
 import numpy as np
 import logging
 
+import pytest
 from obspy import read, UTCDateTime
 
 from eqcorrscan.utils.synth_seis import generate_synth_data
@@ -18,19 +20,20 @@ from eqcorrscan.core.lag_calc import (
 from eqcorrscan.core.match_filter import Detection, Family, Party, Template
 from eqcorrscan.helpers.mock_logger import MockLoggingHandler
 
-np.random.seed(999)
+# np.random.seed(999)
 
 
 class SyntheticTests(unittest.TestCase):
     """ Test lag-calc with synthetic data. """
     @classmethod
     def setUpClass(cls):
+        print("Setting up class")
         samp_rate = 50
-        cls.t_length = .75
+        t_length = .75
         # Make some synthetic templates
         templates, data, seeds = generate_synth_data(
             nsta=5, ntemplates=5, nseeds=10, samp_rate=samp_rate,
-            t_length=cls.t_length, max_amp=10, max_lag=15, phaseout="both",
+            t_length=t_length, max_amp=10, max_lag=15, phaseout="both",
             jitter=0, noise=False, same_phase=True)
         # Rename channels
         channel_mapper = {"SYN_Z": "HHZ", "SYN_H": "HHN"}
@@ -39,7 +42,7 @@ class SyntheticTests(unittest.TestCase):
         for template in templates:
             for tr in template:
                 tr.stats.channel = channel_mapper[tr.stats.channel]
-        cls.party = Party()
+        party = Party()
         t = 0
         data_start = data[0].stats.starttime
         for template, template_seeds in zip(templates, seeds):
@@ -64,9 +67,12 @@ class SyntheticTests(unittest.TestCase):
                 samp_rate=samp_rate, filt_order=4, process_length=86400,
                 prepick=10. / samp_rate, event=None)
             family = Family(template=_template, detections=detections)
-            cls.party += family
+            party += family
             t += 1
+        cls.party = party
         cls.data = data
+        cls.t_length = t_length
+        assert len(data) == 10
 
     def _prepare_data_checks(self, detect_stream_dict, shift_len, family):
         self.assertEqual(
@@ -146,8 +152,8 @@ class SyntheticTests(unittest.TestCase):
             export_cc=False)
         gap = gappy_data.split().get_gaps()
         for event in catalog_dict.values():
-            if len(event.picks) != len(self.data):
-                self.assertEqual(len(event.picks), len(self.data) - 1)
+            if len(event.picks) != len(gappy_data):
+                self.assertEqual(len(event.picks), len(gappy_data) - 1)
                 # Check that the event happened to be in the gap
                 self.assertTrue(gap[0][4] <= event.picks[0].time <= gap[0][5])
                 # Check that there isn't a pick on the channel missing data
@@ -182,16 +188,22 @@ class SyntheticTests(unittest.TestCase):
         self.assertEqual(len(output_cat), len(detections))
         for event in output_cat:
             self.assertEqual(len(event.picks), len(self.data))
+            for pick in event.picks:
+                self.assertTrue("cc_max=" in pick.comments[0].text)
+                self.assertAlmostEqual(
+                    float(pick.comments[0].text.split("=")[-1]), 1.0, 1)
 
     def test_xcorr_pick_family_export_cc(self):
-        cc_dir = 'cc_exported'
+        cc_dir = 'lag_calc_cc_exported'
         xcorr_pick_family(
-            family=self.party[0], stream=self.data, shift_len=0.2, plot=False,
+            family=self.party[0], stream=self.data.copy(), shift_len=0.2, plot=False,
             interpolate=False, export_cc=True, cc_dir=cc_dir)
         cc_files = glob.glob(os.path.join(cc_dir, '*.npy'))
         assert len(cc_files) == len(self.party[0])
         for fcc in cc_files:
             np.load(fcc)
+        if os.path.isdir(cc_dir):
+            shutil.rmtree(cc_dir)
 
 
 class SimpleRealDataTests(unittest.TestCase):

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -8,7 +8,6 @@ import unittest
 import numpy as np
 import logging
 
-import pytest
 from obspy import read, UTCDateTime
 
 from eqcorrscan.utils.synth_seis import generate_synth_data
@@ -196,8 +195,8 @@ class SyntheticTests(unittest.TestCase):
     def test_xcorr_pick_family_export_cc(self):
         cc_dir = 'lag_calc_cc_exported'
         xcorr_pick_family(
-            family=self.party[0], stream=self.data.copy(), shift_len=0.2, plot=False,
-            interpolate=False, export_cc=True, cc_dir=cc_dir)
+            family=self.party[0], stream=self.data.copy(), shift_len=0.2,
+            plot=False, interpolate=False, export_cc=True, cc_dir=cc_dir)
         cc_files = glob.glob(os.path.join(cc_dir, '*.npy'))
         assert len(cc_files) == len(self.party[0])
         for fcc in cc_files:

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -19,7 +19,7 @@ from eqcorrscan.core.lag_calc import (
 from eqcorrscan.core.match_filter import Detection, Family, Party, Template
 from eqcorrscan.helpers.mock_logger import MockLoggingHandler
 
-# np.random.seed(999)
+np.random.seed(999)
 
 
 class SyntheticTests(unittest.TestCase):


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Includes prepick when calculating the start time of extracted windows for lag-calc.

### Why was it initiated?  Any relevant Issues?

When using templates with `prepick`s larger than `shift-len` in `lag_calc` the data extracted do not include the whole window that should be correlated, leading to reduced cccsum errors.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
