### PR TITLE
Fix bug where min_cc for negative correlations

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,9 @@
 * core.lag_calc._xcorr_interp
  - CC-interpolation replaced with resampling (more robust), old method
    deprecated. Use new method with use_new_resamp_method=True as **kwarg.
+* core.lag_calc:
+ - Fixed bug where minimum CC defined via min_cc_from_mean_cc_factor was not
+   set correctly for negative correlation sums.
 * utils.correlate
  - Fast Matched Filter now supported natively for version >= 1.4.0
  - Only full correlation stacks are returned now (e.g. where fewer than than

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -306,8 +306,9 @@ def xcorr_pick_family(family, stream, shift_len=0.2, min_cc=0.4,
         checksum, cccsum, used_chans = 0.0, 0.0, 0
         event = Event()
         if min_cc_from_mean_cc_factor is not None:
-            cc_thresh = min(detection.detect_val / detection.no_chans
-                            * min_cc_from_mean_cc_factor, min_cc)
+            cc_thresh = min(abs(detection.detect_val / detection.no_chans
+                                * min_cc_from_mean_cc_factor),
+                            min_cc)
             Logger.info('Setting minimum cc-threshold for detection %s to %s',
                         detection.id, str(cc_thresh))
         else:


### PR DESCRIPTION
### What does this PR do?
Fixes bug where minimum CC for a pick wasn't set correctly via `min_cc_from_mean_cc_factor` when the total correlation sum was negative.

### Why was it initiated?  Any relevant Issues?
See conversation in https://github.com/eqcorrscan/EQcorrscan/pull/493.

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
