### PR TITLE
WIP: Support more metadata for templates and each template trace

### DIFF
--- a/eqcorrscan/core/match_filter/tribe.py
+++ b/eqcorrscan/core/match_filter/tribe.py
@@ -301,48 +301,43 @@ class Tribe(object):
                 # TODO: add extra info for each trace to event object, write
                 #       into quakeml, and read back from quakeml into trace
                 #       stats
-                trace_ids = [tr.id for tr in t]
-                trace_lengths_npts = [tr.extra.length_npts.value for tr in t]
-                trace_starttimes = [tr.extra.starttime.value for tr in t]
-                trace_endtimes = [tr.extra.endtime.value for tr in t]
-                trace_peak_snrs = [tr.extra.peak_snr.value for tr in t]
-                trace_rms_snrs = [tr.extra.rms_snr.value for tr in t]
-                trace_weights = [tr.extra.weight.value for tr in t]
-                t.event.extra = {
-                    'trace_ids': {
-                    'value': trace_ids,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_lengths_npts': {
-                    'value': trace_lengths_npts,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_starttimes': {
-                    'value': trace_starttimes,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_endtimes': {
-                    'value': trace_endtimes,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_peak_snrs': {
-                    'value': trace_peak_snrs,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_rms_snrs': {
-                    'value': trace_rms_snrs,
-                    'namespace':
-                        'EQC'}}
-                t.event.extra = {
-                    'trace_weights': {
-                    'value': trace_weights,
-                    'namespace':
-                        'EQC'}}
+                trace_ids = [tr.id for tr in t.st]
+                trace_lengths_npts = [
+                    tr.stats.extra.length_npts.value for tr in t.st]
+                trace_starttimes = [
+                    tr.stats.extra.starttime.value for tr in t.st]
+                trace_endtimes = [
+                    tr.stats.extra.endtime.value for tr in t.st]
+                trace_peak_snrs = [
+                    tr.stats.extra.peak_snr.value for tr in t.st]
+                trace_rms_snrs = [
+                    tr.stats.extra.rms_snr.value for tr in t.st]
+                trace_weights = [
+                    tr.stats.extra.weight.value for tr in t.st]
+                namespace = 'EQcorrscan'
+                if not hasattr(t.event, 'extra'):
+                    t.event.extra = {}
+                t.event.extra.update(
+                    {'trace_ids': { 'value': trace_ids,
+                                   'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_lengths_npts': {'value': trace_lengths_npts,
+                                            'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_starttimes': {'value': trace_starttimes,
+                                         'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_endtimes': {'value': trace_endtimes,
+                                        'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_peak_snrs': {'value': trace_peak_snrs,
+                                         'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_rms_snrs': {'value': trace_rms_snrs,
+                                        'namespace': namespace}})
+                t.event.extra.update(
+                    {'trace_weights': {'value': trace_weights,
+                                       'namespace': namespace}})
                 tribe_cat.append(t.event)
         if len(tribe_cat) > 0:
             tribe_cat.write(
@@ -453,7 +448,7 @@ class Tribe(object):
                 tr_ids = event.extra.trace_ids.value
                 tr_starttimes = event.extra.trace_starttimes.value
                 tr_endtimes = event.extra.trace_endtimes.value
-                tr_lengths_npts = event.extra.trace_length_npts.value
+                tr_lengths_npts = event.extra.trace_lengths_npts.value
                 template_st_cut = Stream()
                 for tr_id, tr_starttime, tr_endtime, tr_length_npts in zip(
                         tr_ids, tr_starttimes, tr_endtimes, tr_lengths_npts):
@@ -476,24 +471,26 @@ class Tribe(object):
                     'this should not happen.', template.name)
             namespace = 'EQcorrscan'
             for j_t, tr in enumerate(template.st):
-                tr.stats.extra = {'lengths_npts':
+                if not hasattr(tr.stats, 'extra'):
+                    tr_cut.stats.extra = {}
+                tr.stats.extra.update({'lengths_npts':
                     {'value': template.event.extra.trace_npts.value[j_t],
-                     'namespace': namespace}}
-                tr.stats.extra = {'starttime':
+                     'namespace': namespace}})
+                tr.stats.extra.update({'starttime':
                     {'value': template.event.extra.trace_starttimes.value[j_t],
-                     'namespace': namespace}}
-                tr.stats.extra = {'endtime':
+                     'namespace': namespace}})
+                tr.stats.extra.update({'endtime':
                     {'value': template.event.extra.trace_endtimes.value[j_t],
-                     'namespace': namespace}}
-                tr.stats.extra = {'peak_snr':
+                     'namespace': namespace}})
+                tr.stats.extra.update({'peak_snr':
                     {'value': template.event.extra.trace_peak_snrs.value[j_t],
-                    'namespace': namespace}}
-                tr.stats.extra = {'rms_snr':
+                    'namespace': namespace}})
+                tr.stats.extra.update({'rms_snr':
                     {'value': template.event.extra.trace_rms_snrs.value[j_t],
-                    'namespace': namespace}}
-                tr.stats.extra = {'weight':
+                    'namespace': namespace}})
+                tr.stats.extra.update({'weight':
                     {'value': template.event.extra.trace_weights.value[j_t],
-                    'namespace': namespace}}
+                    'namespace': namespace}})
         except KeyError:
             # TODO decide whether to support tribes without
             #      extended metadata

--- a/eqcorrscan/core/match_filter/tribe.py
+++ b/eqcorrscan/core/match_filter/tribe.py
@@ -316,43 +316,6 @@ class Tribe(object):
                         t.event.extra.update(
                             {event_key: { 'value': trace_extra_parameters,
                                          'namespace': namespace}})
-
-                    # trace_lengths_npts = [
-                    #     tr.stats.extra.length_npts.value for tr in t.st]
-                    # trace_starttimes = [
-                    #     tr.stats.extra.starttime.value for tr in t.st]
-                    # trace_endtimes = [
-                    #     tr.stats.extra.endtime.value for tr in t.st]
-                    # trace_peak_snrs = [
-                    #     tr.stats.extra.peak_snr.value for tr in t.st]
-                    # trace_rms_snrs = [
-                    #     tr.stats.extra.rms_snr.value for tr in t.st]
-                    # trace_weights = [
-                    #     tr.stats.extra.weight.value for tr in t.st]
-                    # namespace = 'EQcorrscan'
-                    # if not hasattr(t.event, 'extra'):
-                    #     t.event.extra = {}
-                    # t.event.extra.update(
-                    #     {'trace_ids': { 'value': trace_ids,
-                    #                 'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_lengths_npts': {'value': trace_lengths_npts,
-                    #                             'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_starttimes': {'value': trace_starttimes,
-                    #                         'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_endtimes': {'value': trace_endtimes,
-                    #                         'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_peak_snrs': {'value': trace_peak_snrs,
-                    #                         'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_rms_snrs': {'value': trace_rms_snrs,
-                    #                         'namespace': namespace}})
-                    # t.event.extra.update(
-                    #     {'trace_weights': {'value': trace_weights,
-                    #                     'namespace': namespace}})
                 except AttributeError:
                     Logger.warning(
                         'Template %s has no extended trace-metadata', t.name)
@@ -506,29 +469,6 @@ class Tribe(object):
                     tr.stats.extra[trace_key].update({
                         value: tr_metadata_value,
                         'namespace': namespace})
-                
-            # namespace = 'EQcorrscan'
-            # for j_t, tr in enumerate(template.st):
-            #     if not hasattr(tr.stats, 'extra'):
-            #         tr.stats.extra = {}
-            #     tr.stats.extra.update({'lengths_npts':
-            #         {'value': template.event.extra.trace_npts.value[j_t],
-            #          'namespace': namespace}})
-            #     tr.stats.extra.update({'starttime':
-            #         {'value': template.event.extra.trace_starttimes.value[j_t],
-            #          'namespace': namespace}})
-            #     tr.stats.extra.update({'endtime':
-            #         {'value': template.event.extra.trace_endtimes.value[j_t],
-            #          'namespace': namespace}})
-            #     tr.stats.extra.update({'peak_snr':
-            #         {'value': template.event.extra.trace_peak_snrs.value[j_t],
-            #         'namespace': namespace}})
-            #     tr.stats.extra.update({'rms_snr':
-            #         {'value': template.event.extra.trace_rms_snrs.value[j_t],
-            #         'namespace': namespace}})
-            #     tr.stats.extra.update({'weight':
-            #         {'value': template.event.extra.trace_weights.value[j_t],
-            #         'namespace': namespace}})
         except (KeyError, AttributeError):
             # TODO decide whether to support tribes without
             #      extended metadata

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -821,30 +821,31 @@ def _template_gen(picks, st, length, swin='all', prepick=0.05,
                 continue
             weight = 1
             namespace = 'EQcorrscan'
-            tr_cut.stats.extra = {
-                'lengths_npts': {
-                    'value': tr_cut.stats.npts,
-                    'namespace': namespace}}
-            tr_cut.stats.extra = {
-                'starttime': {
+            if not hasattr(tr_cut.stats, 'extra'):
+                tr_cut.stats.extra = {}
+            tr_cut.stats.extra.update(
+                {'length_npts': {'value': tr_cut.stats.npts,
+                                 'namespace': namespace}})
+            tr_cut.stats.extra.update(
+                {'starttime': {
                     'value': tr_cut.stats.starttime,
-                    'namespace': namespace}}
-            tr_cut.stats.extra = {
-                'endtime': {
+                    'namespace': namespace}})
+            tr_cut.stats.extra.update(
+                {'endtime': {
                     'value': tr_cut.stats.endtime,
-                    'namespace': namespace}}
-            tr_cut.stats.extra = {
-                'peak_snr': {
+                    'namespace': namespace}})
+            tr_cut.stats.extra.update(
+                {'peak_snr': {
                     'value': peak_snr,
-                    'namespace': namespace}}
-            tr_cut.stats.extra = {
-                'rms_snr': {
+                    'namespace': namespace}})
+            tr_cut.stats.extra.update(
+                {'rms_snr': {
                     'value': rms_snr,
-                    'namespace': namespace}}
-            tr_cut.stats.extra = {
-                'weight': {
+                    'namespace': namespace}})
+            tr_cut.stats.extra.update(
+                {'weight': {
                     'value': weight,
-                    'namespace': namespace}}
+                    'namespace': namespace}})
             st1 += tr_cut
             used_tr = True
         if not used_tr:

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -647,7 +647,7 @@ def _resample(tr, sampling_rate, threads=1):
     x_i = x[1::2]
 
     large_w = np.fft.ifftshift(
-        get_window("hanning", tr.stats.npts))
+        get_window("hann", tr.stats.npts))
     x_r *= large_w[:tr.stats.npts // 2 + 1]
     x_i *= large_w[:tr.stats.npts // 2 + 1]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.12
 matplotlib>=1.3.0
-scipy>=0.18
+scipy>=0.18,<1.9.0
 bottleneck
 obspy>=1.3.0  # ObsPy <1.3.0 is incompatible with numpy >= 1.22: https://github.com/obspy/obspy/issues/2912
 pyfftw  # PyFFTW 0.13 on conda has a build issue: https://github.com/conda-forge/pyfftw-feedstock/issues/51


### PR DESCRIPTION
### What does this PR do?
Implement first ideas / attempts for adding more metadata to templates, including trace-specific metadata.

**Main points:**
- trace.stats.extra is populated with trace metadata during template generation / template reading
- to read / write the trace metadata in a tribe tar-archive, the values are collected from the traces and stored in an `AttribDict` in  [event.extra](https://docs.obspy.org/archive/stable/tutorial/code_snippets/quakeml_custom_tags.html). 
- trace metadata added for now: `weight`, `peak_snr`, `rms_snr`, `starttime`, `endtime`, `length_npts` (i.e., the actual starttime / endtime / npts of each trace BEFORE writing, to allow checks when reading)

### Why was it initiated?  Any relevant Issues?
We've been mentioning for a while that we'd like to save more metadata for each template, and also each trace in the templates. We didn't yet have a way of handling trace-specific metadata that do not fit into miniseed-supported header fields.

**Saving metadata for each trace should allow some more tasks:**
- get ready to support weights for each trace in each template in `matched_filter`
- easy fix for https://github.com/eqcorrscan/EQcorrscan/issues/497
- get ready to extend functionality for some of the wishes listed here: https://github.com/eqcorrscan/EQcorrscan/issues/445, e.g.:
- get ready to support multiple lag-calc picks on same trace-id
- this could also simplify matching picks to their corresponding traces

**Possible downsides:**
- saving trace metadata in the event works well with QuakeML files, but it would not work so easily if we'd like to support saving tribes with Nordic format event files. I don't know how it would be for sc3ml files yet.


@calum-chamberlain , @d-chambers: What do you think about saving trace metadata like this? I went through a few other ideas, but they all seemed to have bigger downsides. 

Example:
```python
from eqcorrscan.core.match_filter import Tribe
from obspy.clients.fdsn import Client

client = Client('NCEDC')
catalog = client.get_events(eventid='72572665', includearrivals=True)
catalog[0].picks = catalog[0].picks[0:5]
tribe = Tribe().construct(
    method='from_client', catalog=catalog, client_id='NCEDC', lowcut=2.0,
    highcut=8.0,  samp_rate=20.0, filt_order=4, length=6.0, prepick=0.1,
    swin='all', process_len=3600, all_horiz=True)

tribe.write('test_tribe.tgz')
tribe_in = Tribe().read('test_tribe.tgz')
tribe[0].st[0].stats.extra
tribe_in[0].st[0].stats.extra
```

### PR Checklist
- [X] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
