### PR TITLE
Uniq detections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
     Fix: only update peak_cores if it isn't there already.
 * core.match_filter.tribe
  - Detect now allows passing of pre-processed data
+* core.match_filter.template
+ - Remove duplicate detections from overlapping windows using `._uniq()`
 * core.lag_calc._xcorr_interp
  - CC-interpolation replaced with resampling (more robust), old method
    deprecated. Use new method with use_new_resamp_method=True as **kwarg.

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -152,13 +152,6 @@ class Detection(object):
     def __ge__(self, other):
         return not self.__lt__(other)
 
-    def __hash__(self):
-        """
-        Cannot hash Detection objects, they may change.
-        :return: 0
-        """
-        return 0
-
     def __ne__(self, other):
         return not self.__eq__(other)
 

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -304,7 +304,8 @@ class Family(object):
 
         .. rubric:: Example
 
-        >>> from eqcorrscan import Template, Detection
+        >>> from eqcorrscan import Template, Detection, Family
+        >>> from obspy import UTCDateTime
         >>> family = Family(
         ...     template=Template(name='a'), detections=[
         ...     Detection(template_name='a', detect_time=UTCDateTime(0),

--- a/eqcorrscan/core/match_filter/template.py
+++ b/eqcorrscan/core/match_filter/template.py
@@ -520,7 +520,10 @@ class Template(object):
             parallel_process=parallel_process, xcorr_func=xcorr_func,
             concurrency=concurrency, cores=cores, ignore_length=ignore_length,
             overlap=overlap, full_peaks=full_peaks, **kwargs)
-        return party[0]
+        family = party[0]
+        # Remove duplicates
+        family.detections = family._uniq().detections
+        return family
 
     def construct(self, method, name, lowcut, highcut, samp_rate, filt_order,
                   length, prepick, swin="all", process_len=86400,


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Make sure `family._uniq()` is called after `Template.detect`. Also makes `Detection` objects unhashable as [they should be](https://docs.python.org/3/reference/datamodel.html#object.__hash__).

### Why was it initiated?  Any relevant Issues?

#431  - note this doesn't address the speed bottleneck in `._uniq` - the method currently deployed is the fastest that I have tested on unhashable `Detection` objects. The biggest speed-up for this would be to make `Detection` object immutable and hashable. But then they wouldn't have the event flexibility that we need.

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
