### PR TITLE
Speedup 01 group templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## Current
+* core.match_filter.template
+  - new quick_group_templates function for 50x quicker template grouping.
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/match_filter/template.py
+++ b/eqcorrscan/core/match_filter/template.py
@@ -714,25 +714,26 @@ def quick_group_templates(templates):
     :type templates: List of Tribe of Templates
     :return: List of Lists of Templates.
     """
-    # Get the template's processing parameters and a unique list of
-    # parameter-combinations
+    # Get the template's processing parameters
     processing_tuples = [
         tuple(
             [value for key, value in template.__dict__.items()
              if key not in ['name', 'st', 'prepick', 'event', 'template_info']]
             )
         for template in templates]
-    # Convert to numpy array to efficiently search for rows with same values
-    processing_array = np.array(processing_tuples)
+    # Get list of unique parameter-tuples. Sort it so that the order in which
+    # the groups are processed is consistent across different runs.
     uniq_processing_parameters = sorted(list(set(processing_tuples)))
     # sort templates into groups
     template_groups = []
     for parameter_combination in uniq_processing_parameters:
-        # find indices of rows with same parameters
-        template_indices_for_group = np.where(
-            (processing_array == np.array(parameter_combination)).all(axis=1))
+        # find indices of tuples in list with same parameters
+        template_indices_for_group = [
+            j for j, param_tuple in enumerate(processing_tuples)
+            if param_tuple == parameter_combination]
+
         new_group = list()
-        for template_index in template_indices_for_group[0]:
+        for template_index in template_indices_for_group: #[0]:
             # use indices to sort templates into groups
             new_group.append(templates[int(template_index)])
         template_groups.append(new_group)

--- a/eqcorrscan/core/match_filter/template.py
+++ b/eqcorrscan/core/match_filter/template.py
@@ -707,6 +707,38 @@ def group_templates(templates):
     return template_groups
 
 
+def quick_group_templates(templates):
+    """
+    Group templates into sets of similarly processed templates.
+
+    :type templates: List of Tribe of Templates
+    :return: List of Lists of Templates.
+    """
+    # Get the template's processing parameters and a unique list of
+    # parameter-combinations
+    processing_tuples = [
+        tuple(
+            [value for key, value in template.__dict__.items()
+             if key not in ['name', 'st', 'prepick', 'event', 'template_info']]
+            )
+        for template in templates]
+    # Convert to numpy array to efficiently search for rows with same values
+    processing_array = np.array(processing_tuples)
+    uniq_processing_parameters = sorted(list(set(processing_tuples)))
+    # sort templates into groups
+    template_groups = []
+    for parameter_combination in uniq_processing_parameters:
+        # find indices of rows with same parameters
+        template_indices_for_group = np.where(
+            (processing_array == np.array(parameter_combination)).all(axis=1))
+        new_group = list()
+        for template_index in template_indices_for_group[0]:
+            # use indices to sort templates into groups
+            new_group.append(templates[int(template_index)])
+        template_groups.append(new_group)
+    return template_groups
+
+
 if __name__ == "__main__":
     import doctest
 

--- a/eqcorrscan/core/match_filter/tribe.py
+++ b/eqcorrscan/core/match_filter/tribe.py
@@ -24,7 +24,8 @@ import numpy as np
 from obspy import Catalog, Stream, read, read_events
 from obspy.core.event import Comment, CreationInfo
 
-from eqcorrscan.core.match_filter.template import Template, group_templates
+from eqcorrscan.core.match_filter.template import (
+    Template, group_templates, quick_group_templates)
 from eqcorrscan.core.match_filter.party import Party
 from eqcorrscan.core.match_filter.helpers import (
     _safemembers, _par_read, get_waveform_client)
@@ -584,7 +585,8 @@ class Tribe(object):
             length is the number of channels within this template.
         """
         party = Party()
-        template_groups = group_templates(self.templates)
+        # template_groups = group_templates(self.templates)
+        template_groups = quick_group_templates(self.templates)
         if len(template_groups) > 1 and pre_processed:
             raise NotImplementedError(
                 "Inconsistent template processing and pre-processed data - "

--- a/eqcorrscan/tests/match_filter_test.py
+++ b/eqcorrscan/tests/match_filter_test.py
@@ -586,6 +586,19 @@ class TestMatchCopy(unittest.TestCase):
             self.assertEqual(t, copy_t)
         self.assertEqual(tribe, copied)
 
+    def test_tribe_copy_quick(self):
+        from robustraqn.templates_creation import _quick_tribe_copy
+        party = Party().read(
+            filename=os.path.join(
+                os.path.abspath(os.path.dirname(__file__)),
+                'test_data', 'test_party.tgz'))
+        tribe = Tribe(f.template for f in party.families)
+        copied = _quick_tribe_copy(tribe)
+        self.assertEqual(len(tribe), len(copied))
+        for t, copy_t in zip(tribe.templates, copied.templates):
+            self.assertEqual(t, copy_t)
+        self.assertEqual(tribe, copied)
+
 
 @pytest.mark.network
 class TestTribeConstruction(unittest.TestCase):


### PR DESCRIPTION
### What does this PR do?
 Gives 50x speed up for grouping templates.

### Why was it initiated?  Any relevant Issues?
Grouping many templates was slow because the function was using a double loop for template-parameter comparison (O^2). So grouping took ~20 s for ~2000 templates. Sped up single loop to <0.5 s.

The new, quick function now circumvents the repeated calls to `template.same_processing` that contribute to the slowdown. So if we change what `template.same_processing` does (i.e., which dict-entries it compares), then we'd also need to change it here. Left in the old function for testing for now.

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
