### PR TITLE
Speedup 02: 3x speed up for prep_data_for_correlation with custom copy and trace-selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,8 @@
 ## Current
+* utils.pre_processing:
+  - _prep_data_for_correlation: 3x speedup for filling NaN-traces in templates
+  - new functions _quick_copy_trace and _quick_stream_copy for 3x quicker
+    trace / stream copy.
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -23,7 +23,7 @@ from eqcorrscan.core.match_filter.helpers import (
 from eqcorrscan.utils.correlate import get_stream_xcorr
 from eqcorrscan.utils.findpeaks import multi_find_peaks
 from eqcorrscan.utils.pre_processing import (
-    dayproc, shortproc, _prep_data_for_correlation)
+    dayproc, shortproc, _prep_data_for_correlation, _quick_copy_stream)
 
 Logger = logging.getLogger(__name__)
 
@@ -324,8 +324,8 @@ def _group_process(template_group, parallel, cores, stream, daylong,
             kwargs.update({'endtime': _endtime})
         else:
             _endtime = kwargs['starttime'] + 86400
-        chunk_stream = stream.slice(starttime=kwargs['starttime'],
-                                    endtime=_endtime).copy()
+        chunk_stream = _quick_copy_stream(
+            stream.slice(starttime=kwargs['starttime'], endtime=_endtime))
         Logger.debug(f"Processing chunk {i} between {kwargs['starttime']} "
                      f"and {_endtime}")
         if len(chunk_stream) == 0:
@@ -666,8 +666,8 @@ def match_filter(template_names, template_list, st, threshold,
     if copy_data:
         # Copy the stream here because we will muck about with it
         Logger.info("Copying data to keep your input safe")
-        stream = st.copy()
-        templates = [t.copy() for t in template_list]
+        stream = _quick_copy_stream(st)
+        templates = [_quick_copy_stream(t) for t in template_list]
         _template_names = template_names.copy()  # This can be a shallow copy
     else:
         stream, templates, _template_names = st, template_list, template_names

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -729,21 +729,6 @@ def _fill_gaps(tr):
     return gaps, tr
 
 
-def _stream_quick_select(stream, seed_id):
-    """
-    4x quicker selection of traces in stream by full Seed-ID. Does not support
-    wildcards or selection by network/station/location/channel alone.
-    """
-    net, sta, loc, chan = seed_id.split('.')
-    stream = Stream(
-        [tr for tr in stream
-         if (tr.stats.network == net and
-             tr.stats.station == sta and
-             tr.stats.location == loc and
-             tr.stats.channel == chan)])
-    return stream
-
-
 def _quick_copy_trace(trace, deepcopy_data=True):
     """
     Function to quickly copy a trace. Sets values in the traces' and trace

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -12,11 +12,9 @@ the data using obspy modules (which also rely on scipy and numpy).
 import numpy as np
 import logging
 import datetime as dt
-from timeit import default_timer
 import copy
 
 from collections import Counter, defaultdict
-from joblib import Parallel, delayed
 from multiprocessing import Pool, cpu_count
 
 from obspy import Stream, Trace, UTCDateTime

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -752,7 +752,8 @@ def _quick_copy_trace(trace, deepcopy_data=True):
             new_stats = new_trace.stats
             for key_2, value_2 in value.__dict__.items():
                 if isinstance(value_2, UTCDateTime):
-                    new_stats.__dict__[key_2] = UTCDateTime(ns=value_2.ns)
+                    new_stats.__dict__[key_2] = UTCDateTime(
+                        ns=value_2.__dict__['_UTCDateTime__ns'])
                 else:
                     new_stats.__dict__[key_2] = value_2
         elif deepcopy_data:

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -12,8 +12,11 @@ the data using obspy modules (which also rely on scipy and numpy).
 import numpy as np
 import logging
 import datetime as dt
+from timeit import default_timer
+import copy
 
-from collections import Counter
+from collections import Counter, defaultdict
+from joblib import Parallel, delayed
 from multiprocessing import Pool, cpu_count
 
 from obspy import Stream, Trace, UTCDateTime
@@ -728,6 +731,59 @@ def _fill_gaps(tr):
     return gaps, tr
 
 
+def _stream_quick_select(stream, seed_id):
+    """
+    4x quicker selection of traces in stream by full Seed-ID. Does not support
+    wildcards or selection by network/station/location/channel alone.
+    """
+    net, sta, loc, chan = seed_id.split('.')
+    stream = Stream(
+        [tr for tr in stream
+         if (tr.stats.network == net and
+             tr.stats.station == sta and
+             tr.stats.location == loc and
+             tr.stats.channel == chan)])
+    return stream
+
+
+def _quick_copy_trace(trace):
+    """
+    Function to quickly copy a trace. Sets values in the traces' and trace
+    header's dict directly, circumventing obspy's init functions.
+    Speedup: from 37 us to 11 us per trace - 3.36x faster
+    """
+    new_trace = Trace()
+    for key, value in trace.__dict__.items():
+        if key == 'stats':
+            new_stats = Stats()
+            for key_2, value_2 in value.__dict__.items():
+                new_stats.__dict__[key_2] = value_2
+                new_trace.__dict__[key] = new_stats
+        else:  # data needs to be deepcopied (and anything else, to be safe)
+            new_trace.__dict__[key] = copy.deepcopy(value)
+    return new_trace
+
+
+def _quick_copy_stream(stream):
+    """
+    Function to quickly copy a stream that consists only of empty data traces.
+    Speedup: from 112 us to 35 us per 3-trace stream - 3.2x faster
+
+    This is what takes longest (1 empty trace, total time to copy 27 us):
+    copy header: 18 us (vs create new empty header: 683 ns)
+
+    Two points that can speed up copying / creation:
+        1. circumvent trace.__init__ and trace.__set_attr__ by setting value
+           directly in trace's __dict__
+        2. when setting trace header, circumvent that Stats(header) is called
+           when header is already a Stats instance
+    """
+    new_traces = list()
+    for trace in stream:
+        new_traces.append(_quick_copy_trace(trace))
+    return Stream(new_traces)
+
+
 def _prep_data_for_correlation(stream, templates, template_names=None,
                                force_stream_epoch=True):
     """
@@ -839,8 +895,8 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
         net, sta, loc, chan = _seed_id[0].split('.')
         nan_template += Trace(header=Stats({
             'network': net, 'station': sta, 'location': loc,
-            'channel': chan, 'starttime': UTCDateTime(),
-            'npts': template_length, 'sampling_rate': samp_rate}))
+            'channel': chan, 'npts': template_length,
+            'sampling_rate': samp_rate}))
 
     # Remove templates with no matching channels
     filt = np.ones(len(template_names)).astype(bool)
@@ -874,8 +930,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 net, sta, loc, chan = earliest_templ_trace_id.split('.')
                 nan_template += Trace(header=Stats({
                     'network': net, 'station': sta, 'location': loc,
-                    'channel': chan, 'starttime': UTCDateTime(),
-                    'npts': template_length, 'sampling_rate': samp_rate}))
+                    'channel': chan, 'sampling_rate': samp_rate}))
                 stream_nan_data = np.full(
                     stream_length, np.nan, dtype=np.float32)
                 out_stream += Trace(
@@ -894,13 +949,27 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
     for template_name in incomplete_templates:
         template = _out[template_name]
         template_starttime = min(tr.stats.starttime for tr in template)
-        out_template = nan_template.copy()
+        # out_template = nan_template.copy()
+        out_template = _quick_copy_stream(nan_template)
+
+        # Select traces very quickly: assume that trace order does not change,
+        # make dict of trace-ids and list of indices and use indices to select
+        stream_trace_id_dict = defaultdict(list)
+        for n, tr in enumerate(template.traces):
+            stream_trace_id_dict[tr.id].append(n)
+
         for channel_number, _seed_id in enumerate(seed_ids):
             seed_id, channel_index = _seed_id
-            template_channel = template.select(id=seed_id)
+            # Select all traces with same seed_id, based on indices for
+            # corresponding traces stored in stream_trace_id_dict
+            # Much quicker than: template_channel = template.select(id=seed_id)
+            template_channel = Stream([
+                template.traces[idx] for idx in stream_trace_id_dict[seed_id]])
             if len(template_channel) <= channel_index:
-                out_template[channel_number].data = nan_channel
-                out_template[channel_number].stats.starttime = \
+                # Direct changing of trace dict is very quick:
+                out_template[channel_number].__dict__['data'] = nan_channel
+                out_template[channel_number].__dict__['npts'] = template_length
+                out_template[channel_number].__dict__['starttime'] = \
                     template_starttime
             else:
                 out_template[channel_number] = template_channel[channel_index]

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -987,9 +987,14 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 # out_template[channel_number].data = nan_channel  # quicker:
                 out_template[channel_number].__dict__['data'] = copy.deepcopy(
                     nan_channel)
-                out_template[channel_number].__dict__['npts'] = template_length
-                out_template[channel_number].__dict__['starttime'] = \
+                out_template[channel_number].stats.__dict__['npts'] = \
+                    template_length
+                out_template[channel_number].stats.__dict__['starttime'] = \
                     template_starttime
+                out_template[channel_number].stats.__dict__['endtime'] = \
+                    UTCDateTime(ns=int(
+                        round(template_starttime.ns
+                              + (template_length * samp_rate) * 1e9)))
             else:
                 out_template[channel_number] = template_channel[channel_index]
         # If a template-trace matches a NaN-trace in the stream , then set


### PR DESCRIPTION
### What does this PR do?
- 3x speed up for function `preprocessing._prep_data_for_correlation`
- provides new functions `_quick_copy_trace` and `_quick_stream_copy` that are ~3x quicker for copying simple traces by avoiding a call to `copy.deepcopy` where that is not necessary. So it helps with traces that mostly contain data, but will not speed up copying as much for traces with attached response and longer history.
 
### Why was it initiated?  Any relevant Issues?
When a user has a big set of heterogeneous templates (i.e., many templates with different station setups), filling the templates with NaN-channels takes a long time (many copy-operations in serial). This PR speeds that process up by a factor of 3 in my example, going from ca. 150 s to 50 s for 1500 templates with up to 500 channels.

This PR contributes to the summary issue in https://github.com/eqcorrscan/EQcorrscan/issues/522

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
