### PR TITLE
Speedup 04: quick trace selection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 ## Current
+* utils.pre_processing
+  - New function ``quick_trace_select` for a very efficient selection of trace
+    by seed ID without wildcards (4x speedup).
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/lag_calc.py
+++ b/eqcorrscan/core/lag_calc.py
@@ -24,6 +24,7 @@ from eqcorrscan.utils.correlate import get_stream_xcorr
 from eqcorrscan.core.match_filter.family import Family
 from eqcorrscan.core.match_filter.template import Template
 from eqcorrscan.utils.plotting import plot_repicked
+from eqcorrscan.utils.pre_processing import _stream_quick_select
 
 show_interp_deprec_warning = True
 
@@ -168,7 +169,8 @@ def _concatenate_and_correlate(streams, template, cores):
     for i, chan in enumerate(chans):
         start_index = 0
         for j, stream in enumerate(streams):
-            tr = stream.select(id=chan)
+            # tr = stream.select(id=chan)
+            tr = _stream_quick_select(stream, chan)
             if len(tr) == 0:
                 # No data for this channel in this stream
                 used_chans[j].append(UsedChannel(

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -23,6 +23,7 @@ from obspy.core.event import (
     Origin)
 
 from eqcorrscan.core.match_filter.helpers import _test_event_similarity
+from eqcorrscan.utils.pre_processing import _stream_quick_select
 
 Logger = logging.getLogger(__name__)
 
@@ -284,7 +285,8 @@ class Detection(object):
                     new_pick.phase_hint = template_pick[0].phase_hint
                 else:
                     # Multiple picks for this trace in template
-                    similar_traces = template_st.select(id=tr.id)
+                    # similar_traces = template_st.select(id=tr.id)
+                    similar_traces = _stream_quick_select(template_st, tr.id)
                     similar_traces.sort()
                     _index = similar_traces.traces.index(tr)
                     try:

--- a/eqcorrscan/core/match_filter/template.py
+++ b/eqcorrscan/core/match_filter/template.py
@@ -26,7 +26,6 @@ from eqcorrscan.core.match_filter.helpers import _test_event_similarity
 from eqcorrscan.core.match_filter.matched_filter import (
     _group_detect, MatchFilterError)
 from eqcorrscan.core import template_gen
-from eqcorrscan.utils.pre_processing import _stream_quick_select
 
 Logger = logging.getLogger(__name__)
 

--- a/eqcorrscan/core/match_filter/template.py
+++ b/eqcorrscan/core/match_filter/template.py
@@ -26,6 +26,7 @@ from eqcorrscan.core.match_filter.helpers import _test_event_similarity
 from eqcorrscan.core.match_filter.matched_filter import (
     _group_detect, MatchFilterError)
 from eqcorrscan.core import template_gen
+from eqcorrscan.utils.pre_processing import _stream_quick_select
 
 Logger = logging.getLogger(__name__)
 

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -1128,7 +1128,6 @@ def _get_array_dicts(templates, stream, stack, copy_streams=True):
         temps_with_seed = [template[i].data for template in templates]
         t_ar = np.array(temps_with_seed).astype(np.float32)
         template_dict.update({seed_id: t_ar})
-        # stream_channel = stream.select(id=seed_id.split('_')[0])[0]
         stream_channel = _stream_quick_select(stream, seed_id.split('_')[0])[0]
         # Normalize data to ensure no float overflow
         stream_data = stream_channel.data / (np.max(

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -32,6 +32,7 @@ from packaging import version
 
 from eqcorrscan.utils.libnames import _load_cdll
 from eqcorrscan.utils import FMF_INSTALLED
+from eqcorrscan.utils.pre_processing import _stream_quick_select
 
 
 Logger = logging.getLogger(__name__)
@@ -1127,7 +1128,8 @@ def _get_array_dicts(templates, stream, stack, copy_streams=True):
         temps_with_seed = [template[i].data for template in templates]
         t_ar = np.array(temps_with_seed).astype(np.float32)
         template_dict.update({seed_id: t_ar})
-        stream_channel = stream.select(id=seed_id.split('_')[0])[0]
+        # stream_channel = stream.select(id=seed_id.split('_')[0])[0]
+        stream_channel = _stream_quick_select(stream, seed_id.split('_')[0])[0]
         # Normalize data to ensure no float overflow
         stream_data = stream_channel.data / (np.max(
             np.abs(stream_channel.data)) / 1e5)

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -916,7 +916,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
         stream_trace_id_dict = defaultdict(list)
         for n, tr in enumerate(template.traces):
             stream_trace_id_dict[tr.id].append(n)
-        
+
         for channel_number, _seed_id in enumerate(seed_ids):
             seed_id, channel_index = _seed_id
             # Select all traces with same seed_id, based on indices for

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -13,7 +13,7 @@ import numpy as np
 import logging
 import datetime as dt
 
-from collections import Counter
+from collections import Counter, defaultdict
 from multiprocessing import Pool, cpu_count
 
 from obspy import Stream, Trace, UTCDateTime
@@ -728,6 +728,21 @@ def _fill_gaps(tr):
     return gaps, tr
 
 
+def _stream_quick_select(stream, seed_id):
+    """
+    4x quicker selection of traces in stream by full Seed-ID. Does not support
+    wildcards or selection by network/station/location/channel alone.
+    """
+    net, sta, loc, chan = seed_id.split('.')
+    stream = Stream(
+        [tr for tr in stream
+         if (tr.stats.network == net and
+             tr.stats.station == sta and
+             tr.stats.location == loc and
+             tr.stats.channel == chan)])
+    return stream
+
+
 def _prep_data_for_correlation(stream, templates, template_names=None,
                                force_stream_epoch=True):
     """
@@ -895,9 +910,20 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
         template = _out[template_name]
         template_starttime = min(tr.stats.starttime for tr in template)
         out_template = nan_template.copy()
+
+        # Select traces very quickly: assume that trace order does not change,
+        # make dict of trace-ids and list of indices and use indices to select
+        stream_trace_id_dict = defaultdict(list)
+        for n, tr in enumerate(template.traces):
+            stream_trace_id_dict[tr.id].append(n)
+        
         for channel_number, _seed_id in enumerate(seed_ids):
             seed_id, channel_index = _seed_id
-            template_channel = template.select(id=seed_id)
+            # Select all traces with same seed_id, based on indices for
+            # corresponding traces stored in stream_trace_id_dict
+            # Much quicker than: template_channel = template.select(id=seed_id)
+            template_channel = Stream([
+                template.traces[idx] for idx in stream_trace_id_dict[seed_id]])
             if len(template_channel) <= channel_index:
                 out_template[channel_number].data = nan_channel
                 out_template[channel_number].stats.starttime = \


### PR DESCRIPTION
### What does this PR do?
-  4x / 100x speedup for trace selection in `detection`, `lag_calc`,  `pre_processing`

### Why was it initiated?  Any relevant Issues?
-  trace selection by trace id from a stream is still something that takes more time than it needs to when working with many thousand (100K?) traces, even after https://github.com/obspy/obspy/pull/2886.
- When a user doesn't need wildcard selection, than the simple selection function can be sped up by a factor of 4 compared to `obspy.stream.select` 
- For the time when the order of traces in a stream does not change and a lot of traces need to be selected from that stream, then it's possible to speed up the selection by a factor of ~100 with a dict-lookup - this is very relevant for the template preparation in `_prep_data_for_correlation`

This PR contributes to the summary issue in https://github.com/eqcorrscan/EQcorrscan/issues/522

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
- [X] Any new or changed features have are fully documented.
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
