### PR TITLE
Speedup 05: Retrieve unique detections in family and in `matched_filter`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 ## Current
+* core.match_filter
+  - 1.9x speed up for `family._uniq`.
+  - `detect`: 1000x speedup for retrieving unique detections for all templates.
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -297,7 +297,6 @@ class Family(object):
         """
         return len(self.detections)
 
-
     def _uniq(self):
         """
         Get list of unique detections.

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -328,8 +328,6 @@ class Family(object):
         """
         _detections = []
         _detections = list(set(self.detections))
-        # [_detections.append(d) for d in self.detections
-        # if not _detections.count(d)]
         self.detections = _detections
         return self
 

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -326,8 +326,8 @@ class Family(object):
         2
         """
         _detections = []
-        _detections = [_detections.append(d) for d in self.detections
-                       if not _detections.count(d)]
+        [_detections.append(d) for d in self.detections
+         if not _detections.count(d)]
         self.detections = _detections
         return self
 

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -297,6 +297,7 @@ class Family(object):
         """
         return len(self.detections)
 
+
     def _uniq(self):
         """
         Get list of unique detections.
@@ -326,8 +327,9 @@ class Family(object):
         2
         """
         _detections = []
-        [_detections.append(d) for d in self.detections
-         if not _detections.count(d)]
+        _detections = list(set(self.detections))
+        # [_detections.append(d) for d in self.detections
+        # if not _detections.count(d)]
         self.detections = _detections
         return self
 

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -326,7 +326,8 @@ class Family(object):
         2
         """
         _detections = []
-        _detections = list(set(self.detections))
+        _detections = [_detections.append(d) for d in self.detections
+                       if not _detections.count(d)]
         self.detections = _detections
         return self
 

--- a/eqcorrscan/core/match_filter/tribe.py
+++ b/eqcorrscan/core/match_filter/tribe.py
@@ -606,7 +606,21 @@ class Tribe(object):
         if len(party) > 0:
             for family in party:
                 if family is not None:
-                    family.detections = family._uniq().detections
+                    # Slow uniq:
+                    # family.detections = family._uniq().detections
+                    # Very quick uniq:
+                    det_tuples = [
+                        (det.id, str(det.detect_time), det.detect_val)
+                        for det in family]
+                    # Retrieve the indices for the first occurrence of each
+                    # detection in the family (so only unique detections will
+                    # remain).
+                    uniq_det_tuples, uniq_det_indices = np.unique(
+                        det_tuples, return_index=True, axis=0)
+                    uniq_detections = []
+                    for uniq_det_index in uniq_det_indices:
+                        uniq_detections.append(family[uniq_det_index])
+                    family.detections = uniq_detections
         return party
 
     def client_detect(self, client, starttime, endtime, threshold,


### PR DESCRIPTION
### What does this PR do?
- `core.match_filter.family._uniq`: **1.9x speedup**
  - retrieving the unique list of detections is quicker for many detections with `list(set)` (1.9x speedup for 43000 detections, fastest: 3.1 s), but 1.2x slower for small sets (e.g., 430 detections; 50 ms --> 27 ms).
- `core.match_filter.detect` - **1000x speed up for many calls to `family._uniq`**
  -  using `family._uniq` in a loop over all families is still rather slow with `_uniq`. Checking tuples of `(detection.id, detection.detect_time, detection.detect_val)` with `numpy.unique` and avoiding a loop is 1000x faster.  From 752 s to <1 s for 82000 detections.

### Why was it initiated?  Any relevant Issues?
Retrieving unique detections for `matched_filter`-run was getting slower than needed when there are a lot of detections.

This PR contributes to the summary issue in https://github.com/eqcorrscan/EQcorrscan/issues/522

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
