### PR TITLE
Speedup 06: 30x speedup for _group_detect - handling detections

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 ## Current
+* core.match_filter
+  - 30x speedup in handling detections (50x speedup in selecting detections,
+    4x speedup in adding prepick time)
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -13,6 +13,7 @@ with data and output the detections.
 """
 import logging
 from timeit import default_timer
+from collections import defaultdict
 
 import numpy as np
 from obspy import Catalog, UTCDateTime, Stream
@@ -230,15 +231,30 @@ def _group_detect(templates, stream, threshold, threshold_type, trig_int,
                 threshold=threshold, threshold_type=threshold_type,
                 trig_int=trig_int, plot=plot, plotdir=plotdir, cores=cores,
                 full_peaks=full_peaks, **kwargs)
+            # detections_template_names = [detection.template_name
+            #                             for detection in detections]
+            # Select detections very quickly: detection order does not
+            # change, make dict of keys: template-names and values:
+            # list of indices and use indices to select
+            detection_idx_dict = defaultdict(list)
+            for n, detection in enumerate(detections):
+                detection_idx_dict[detection.template_name].append(n)
+
             for template in template_group:
                 family = Family(template=template, detections=[])
-                for detection in detections:
-                    if detection.template_name == template.name:
+                fam_detections = [
+                    detections[idx]
+                    for idx in detection_idx_dict[family.template.name]]
+                for detection in fam_detections:
+                    if detection.event:
+                        # Add template prepick to the pick time (direct adding
+                        # to UTCDateTime.ns is quickest for many iterations).
                         for pick in detection.event.picks:
-                            pick.time += template.prepick
+                            pick.time.ns += int(round(template.prepick * 1e9))
                         for origin in detection.event.origins:
-                            origin.time += template.prepick
-                        family.detections.append(detection)
+                            origin.time.ns += int(round(
+                                template.prepick * 1e9))
+                    family.detections.append(detection)
                 party += family
     return party
 

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -231,8 +231,6 @@ def _group_detect(templates, stream, threshold, threshold_type, trig_int,
                 threshold=threshold, threshold_type=threshold_type,
                 trig_int=trig_int, plot=plot, plotdir=plotdir, cores=cores,
                 full_peaks=full_peaks, **kwargs)
-            # detections_template_names = [detection.template_name
-            #                             for detection in detections]
             # Select detections very quickly: detection order does not
             # change, make dict of keys: template-names and values:
             # list of indices and use indices to select


### PR DESCRIPTION
### What does this PR do?
- `matched_filter._group_detect`: **30x speedup in handling detections**
  - selecting detections by template name in big list can be slow via loop. Dict-lookup offers ~50x speedup
  - adding `prepick` to many picks (e.g., 400k) is somewhat slow because of `UTCDateTime` overhead. ~4x speedup with adding to `pick.time.ns` directly.

### Why was it initiated?  Any relevant Issues?
Collecting / handling detections after a `matched_filter` run was getting slow for many detections and templates.

This PR contributes to the summary issue in https://github.com/eqcorrscan/EQcorrscan/issues/522

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
