### PR TITLE
Bugfix: Consistent trace slicing length for catalog_to_dd._prepare_stream

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 ## Current
+* utils.catalog_to_dd._prepare_stream
+  - Now more consistently slices templates to length = extract_len * samp_rate
+    so that user receives less warnings about insufficient data.
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/tests/catalog_to_dd_test.py
+++ b/eqcorrscan/tests/catalog_to_dd_test.py
@@ -148,8 +148,8 @@ class TestCatalogMethods(unittest.TestCase):
         self.assertEqual(len(s_picks), len(sliced_stream["S"]))
         for stream in sliced_stream.values():
             for tr in stream:
-                self.assertEqual(
-                    tr.stats.endtime - tr.stats.starttime, extract_len)
+                self.assertEqual(tr.stats.npts,
+                                 extract_len * tr.stats.sampling_rate)
 
     def test_read_phase(self):
         """Function to test the phase reading function"""


### PR DESCRIPTION
### What does this PR do?
Consistently slices traces in `utils.catalog_to_dd.prepare_stream` according to the same convention that is applied in `utils.pre_processing`: When traces end up with `(extract_len * samp_rate) + 1` samples because the chosen start time falls exactly on the first sample, then we remove the first sample from the trace.

Consequences:
- There are more correlation results in dt.cc
- The correlation times in `dt.cc` remain the same.
- The normalized cross-correlation values can change by +/- 0.0001 (precision of values is 0.0001)

### Why was it initiated?  Any relevant Issues?
`utils.catalog_to_dd.write_correlations` was printing many warnings about insufficient data because some traces (those where the starttime did not coincide exactly with a sample) were 1 sample shorter than others.

I was a bit surprised we didn't catch this earlier... hope I'm not missing anything here. I fixed the test for `_prepare_stream` so that it now checks the length is `extract_len * samp_rate` (1000 samples, 9.99 s), not `starttime - endtime` (1001 samples, 10 s) as it was until now. 

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [X] All tests still pass.
- [X] Any new features or fixed regressions are be covered via new tests.
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
