### PR TITLE
Speedup 07: 2.5x speedup with parallel parallel median / MAD calculation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 ## Current
+* core.match_filter.matched_filter
+  - 2.5x speed up for MAD threshold calculation with parallel median.
 
 ## 0.4.4
 * core.match_filter

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -713,7 +713,7 @@ def match_filter(template_names, template_list, st, threshold,
             median_cores = min([cores, len(cccsums)])
             if len(cccsums) * len(cccsums[0]) < 2e7:  # parallel not worth it
                 median_cores = 1
-            with ThreadPoolExecutor(max_workers=median_cores) as executor:  
+            with ThreadPoolExecutor(max_workers=median_cores) as executor:
                 # Because numpy releases GIL threading can use multiple cores
                 medians = executor.map(_mad, cccsums)
             thresholds = [threshold * median for median in medians]

--- a/eqcorrscan/core/match_filter/matched_filter.py
+++ b/eqcorrscan/core/match_filter/matched_filter.py
@@ -709,12 +709,16 @@ def match_filter(template_names, template_list, st, threshold,
     if str(threshold_type) == str("absolute"):
         thresholds = [threshold for _ in range(len(cccsums))]
     elif str(threshold_type) == str('MAD'):
-        median_cores = min([cores, len(cccsums)])
-        if len(cccsums) * len(cccsums[0]) < 2e7:  # parallel not worth it below
-            median_cores = 1
-        medians = Parallel(n_jobs=median_cores)(delayed(
-            _mad)(cccsum) for cccsum in cccsums)
-        thresholds = [threshold * median for median in medians]
+        if cores:
+            median_cores = min([cores, len(cccsums)])
+            if len(cccsums) * len(cccsums[0]) < 2e7:  # parallel not worth it
+                median_cores = 1
+            medians = Parallel(n_jobs=median_cores)(delayed(
+                _mad)(cccsum) for cccsum in cccsums)
+            thresholds = [threshold * median for median in medians]
+        else:
+            thresholds = [threshold * np.median(np.abs(cccsum))
+                          for cccsum in cccsums]
     else:
         thresholds = [threshold * no_chans[i] for i in range(len(cccsums))]
     if peak_cores is None:


### PR DESCRIPTION
### What does this PR do?
Implements 2.5x speedup for MAD threshold calculation in `core.match_filter.matched_filter`.  With this PR, MAD thresholds can be calculated in parallel; with joblib this is already worth it with a relatively small dataset (> 15 cccsum or 2e7 values in cccsums).

This has a noticeable effect for larger datasets, e.g., for 2000 templates, this reduced MAD-calculation from 50 s to 20 s with 30 cores.

### Why was it initiated?  Any relevant Issues?
- Computing median is not a cheap operation for big arrays, even in numpy.
- I checked two other ways for speeding this up:
  - full vectorization with numpy --> 30 % slower than serial list-comprehension
  - parallelization with Pool --> 50% slower than serial

This PR contributes to the summary issue in https://github.com/eqcorrscan/EQcorrscan/issues/522

Examples for comparing serial and parallel MAD:
```python
import numpy as np
from joblib import delayed, Parallel
from multiprocessing import Pool

def _mad(cccsum):
    """
    Internal helper to compute MAD-thresholds in parallel.
    """
    return np.median(np.abs(cccsum))

median_cores = 20
threshold = 8
cccsums = [np.random.randn(2000000) for j in range(100) ]

thresholds_ser = [threshold * np.median(np.abs(cccsum)) for cccsum in cccsums]

pool = Pool(processes=median_cores)
results = [pool.apply_async(_mad, ([cccsum]),) for cccsum in cccsums]
pool.close()
thresholds_pool = [threshold * p.get() for p in results]

medians = Parallel(n_jobs=median_cores)(delayed(
    _mad)(cccsum) for cccsum in cccsums)
thresholds_joblib = [threshold * median for median in medians]

for item1, item2 in zip(thresholds_ser, thresholds_joblib):
    if item1 != item2:
        print('not equal')

%timeit pool = Pool(processes=median_cores); results = [pool.apply_async(_mad, ([cccsum]),) for cccsum in cccsums]; pool.close(); pool_tresholds = [threshold * p.get() for p in results]
%timeit [threshold * np.median(np.abs(cccsum)) for cccsum in cccsums]
%timeit Parallel(n_jobs=median_cores)(delayed(_mad)(cccsum) for cccsum in cccsums)

```

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
