### PR TITLE
Bump obspy version for NCEDC tests

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -7,7 +7,7 @@ dependencies:
   - matplotlib>=1.3.0
   - scipy>=0.18,<1.9.0  # Pinned due to scipy/obspy hanning renaming
   - mock
-  - obspy>=1.3.0
+  - obspy>=1.4.0
   - h5py
   - pyyaml
   - bottleneck

--- a/.github/test_conda_env_macOS.yml
+++ b/.github/test_conda_env_macOS.yml
@@ -16,7 +16,7 @@ dependencies:
   - matplotlib>=1.3.0
   - scipy>=0.18,<1.9.0  # Pinned due to scipy/obspy hanning renaming
   - mock
-  - obspy>=1.3.0
+  - obspy>=1.4.0
   - h5py<3.2  # Issue with dep resolution: https://github.com/conda-forge/h5py-feedstock/issues/92
   - pyyaml
   - bottleneck


### PR DESCRIPTION
NCEDC changed their URL and this is fixed in obspy v 1.4.0
