### PR TITLE
Speedup 10:  25 % quicker _get_array_dicts and 10 % quicker _prep_data_for_correlation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,8 @@
   - `_prep_data_for_correlation`: 3x speedup for filling NaN-traces in templates
   - New function ``quick_trace_select` for a very efficient selection of trace
     by seed ID without wildcards (4x speedup).
+* utils.correlate
+  - 25 % speedup for `_get_array_dicts` with quicker access to properties.
 * utils.catalog_to_dd._prepare_stream
   - Now more consistently slices templates to length = extract_len * samp_rate
     so that user receives less warnings about insufficient data.

--- a/eqcorrscan/utils/correlate.py
+++ b/eqcorrscan/utils/correlate.py
@@ -1129,7 +1129,7 @@ def _get_array_dicts(templates, stream, stack, copy_streams=True):
     seed_ids = [tr.id + '_' + str(i) for i, tr in enumerate(templates[0])]
     # pull common channels out of streams and templates and put in dicts
     for i, seed_id in enumerate(seed_ids):
-        temps_with_seed = [template[i].data for template in templates]
+        temps_with_seed = [template.traces[i].data for template in templates]
         t_ar = np.array(temps_with_seed).astype(np.float32)
         template_dict.update({seed_id: t_ar})
         stream_channel = _stream_quick_select(stream, seed_id.split('_')[0])[0]
@@ -1143,12 +1143,13 @@ def _get_array_dicts(templates, stream, stack, copy_streams=True):
         # pad_list can become 0. 0-1 = -1; which is problematic.
         stream_offset = int(
             math.floor(stream_channel.stats.sampling_rate *
-                  (stream_channel.stats.starttime - stream_start)))
+                       (stream_channel.stats.starttime - stream_start)))
         if stack:
             pad_list = [
                 int(round(
-                    template[i].stats.sampling_rate *
-                    (template[i].stats.starttime.__dict__['_UTCDateTime__ns'] -
+                    template.traces[i].stats.__dict__['sampling_rate'] *
+                    (template.traces[i].stats.starttime.__dict__[
+                        '_UTCDateTime__ns'] -
                      t_starts[j].__dict__['_UTCDateTime__ns']) / 1e9)) -
                 stream_offset
                 for j, template in enumerate(templates)]

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -1000,7 +1000,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
             if len(template_channel) <= channel_index:
                 # out_template[channel_number].data = nan_channel  # quicker:
                 out_template.traces[channel_number].__dict__[
-                    'data'] = copy.deepcopy(nan_channel)
+                    'data'] = np.copy(nan_channel)
                 out_template.traces[channel_number].stats.__dict__[
                     'npts'] = template_length
                 out_template.traces[channel_number].stats.__dict__[

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -1008,7 +1008,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 out_template.traces[channel_number].stats.__dict__[
                     'endtime'] = UTCDateTime(ns=int(
                         round(template_starttime.ns
-                              + (template_length * samp_rate) * 1e9)))
+                              + (template_length * samp_rate) / 1e9)))
             else:
                 out_template.traces[channel_number] = template_channel.traces[
                     channel_index]

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -1008,7 +1008,7 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 out_template.traces[channel_number].stats.__dict__[
                     'endtime'] = UTCDateTime(ns=int(
                         round(template_starttime.ns
-                              + (template_length * samp_rate) / 1e9)))
+                              + (template_length / samp_rate) * 1e9)))
             else:
                 out_template.traces[channel_number] = template_channel.traces[
                     channel_index]

--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -999,18 +999,20 @@ def _prep_data_for_correlation(stream, templates, template_names=None,
                 template.traces[idx] for idx in stream_trace_id_dict[seed_id]])
             if len(template_channel) <= channel_index:
                 # out_template[channel_number].data = nan_channel  # quicker:
-                out_template[channel_number].__dict__['data'] = copy.deepcopy(
-                    nan_channel)
-                out_template[channel_number].stats.__dict__['npts'] = \
-                    template_length
-                out_template[channel_number].stats.__dict__['starttime'] = \
-                    template_starttime
-                out_template[channel_number].stats.__dict__['endtime'] = \
-                    UTCDateTime(ns=int(
+                out_template.traces[channel_number].__dict__[
+                    'data'] = copy.deepcopy(nan_channel)
+                out_template.traces[channel_number].stats.__dict__[
+                    'npts'] = template_length
+                out_template.traces[channel_number].stats.__dict__[
+                    'starttime'] = template_starttime
+                out_template.traces[channel_number].stats.__dict__[
+                    'endtime'] = UTCDateTime(ns=int(
                         round(template_starttime.ns
                               + (template_length * samp_rate) * 1e9)))
             else:
-                out_template[channel_number] = template_channel[channel_index]
+                out_template.traces[channel_number] = template_channel.traces[
+                    channel_index]
+
         # If a template-trace matches a NaN-trace in the stream , then set
         # template-trace to NaN so that this trace does not appear in channel-
         # list of detections.


### PR DESCRIPTION
### What does this PR do?
Implements:
- 25 % speedup for `utils.correlate._get_array_dicts` (from 200 s to 154 seconds total time spent in my test)
- 10 % speedup for `utils.pre_processing._prep_data_for_correlation` (from 702 s to 640 s total time spent)
- (for comparison to the numbers above: 494 s were spent for correlating data in parallel on the GPU)

Main speedups with:
- direct operations on `UTCDateTime.__dict__['_UTCDateTime__ns']` (5x quicker for one +/- operation)
- index-based access to trace in stream with `stream.traces[j]` instead of `stream[j]` (4.5x quicker)

### Why was it initiated?  Any relevant Issues?
For big datasets run on powerful hardware, the cumulative time spent in `utils.correlate._get_array_dicts` and `utils.pre_processing._prep_data_for_correlation` makes up a considerable part (>50 %) of a detection run. This PR tries to optimize the functions with some simple changes; I think further speed ups would need changes that are not so trivial...

This PR is part of the list of speedups in https://github.com/eqcorrscan/EQcorrscan/issues/522

### PR Checklist
- [X] `develop` base branch selected?
- [X] This PR is not directly related to an existing issue (which has no PR yet).
- [] All tests still pass.
~- [ ] Any new features or fixed regressions are be covered via new tests.~
~- [ ] Any new or changed features have are fully documented.~
- [X] Significant changes have been added to `CHANGES.md`.
~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~
