### PR TITLE
Force Party instantiation to be made from Families

### DIFF
--- a/eqcorrscan/core/match_filter/party.py
+++ b/eqcorrscan/core/match_filter/party.py
@@ -53,6 +53,10 @@ class Party(object):
         if isinstance(families, Family):
             families = [families]
         if families:
+            assert isinstance(families, list), \
+                "Families must be list of Family objects"
+            assert all(isinstance(f, Family) for f in families), \
+                "Families must be list of Family objects"
             self.families.extend(families)
 
     def __repr__(self):


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Raises an assertion error if the wrong type is provided to Party on init

### Why was it initiated?  Any relevant Issues?

I frequently accidentally instantiate a party with a string. This should not be allowed.

### PR Checklist
~~- [ ] `develop` base branch selected?~~
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
