### PR TITLE
Raise useful error when waveform_id is incomplete

### DIFF
--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -524,7 +524,8 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
             if pick.waveform_id.channel_code is None:
                 Logger.error(f"Missing waveform_id.channel_code for Pick {pick}.")
                 raise TemplateGenError(
-                    "Ensure that all picks have complete waveform_id attributes")
+                    "Ensure that all picks have complete "
+                    "waveform_id attributes")
             if all_channels:
                 channel_code = pick.waveform_id.channel_code[0:2] + "?"
             else:

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -521,6 +521,10 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
                     "Pick not associated with waveforms, will not use:"
                     " {0}".format(pick))
                 continue
+            if pick.waveform_id.channel_code is None:
+                Logger.error(f"Missing waveform_id.channel_code for Pick {pick}.")
+                raise TemplateGenError(
+                    "Ensure that all picks have complete waveform_id attributes")
             if all_channels:
                 channel_code = pick.waveform_id.channel_code[0:2] + "?"
             else:

--- a/eqcorrscan/core/template_gen.py
+++ b/eqcorrscan/core/template_gen.py
@@ -522,7 +522,8 @@ def _download_from_client(client, client_type, catalog, data_pad, process_len,
                     " {0}".format(pick))
                 continue
             if pick.waveform_id.channel_code is None:
-                Logger.error(f"Missing waveform_id.channel_code for Pick {pick}.")
+                Logger.error(
+                    f"Missing waveform_id.channel_code for Pick {pick}.")
                 raise TemplateGenError(
                     "Ensure that all picks have complete "
                     "waveform_id attributes")


### PR DESCRIPTION
See #563 - some picks from FDSN services are missing channel codes resulting in an opaque and hard to understand error.

<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?
Adds a useful error message when waveform_ids are incomplete when generating templates.

### Why was it initiated?  Any relevant Issues?
#563 

### PR Checklist
- [x] `develop` base branch selected?
- [ ] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
- [ ] Any new features or fixed regressions are be covered via new tests.
- [ ] Any new or changed features have are fully documented.
- [ ] Significant changes have been added to `CHANGES.md`.
- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.
