### PR TITLE
Drop last sample, not first

### DIFF
--- a/eqcorrscan/utils/pre_processing.py
+++ b/eqcorrscan/utils/pre_processing.py
@@ -129,10 +129,11 @@ def _sanitize_length(st, starttime=None, endtime=None, daylong=False):
                 tr.trim(starttime, endtime)
                 if len(tr.data) == ((endtime - starttime) *
                                     tr.stats.sampling_rate) + 1:
-                    Logger.info(f"{tr.id} is overlength dropping first sample")
-                    tr.data = tr.data[1:len(tr.data)]
-                    # TODO: this should adjust the start-time
-                    # tr.stats.starttime += tr.stats.delta
+                    Logger.info(f"{tr.id} between {tr.stats.starttime} and "
+                                f"{tr.stats.endtime} with {tr.stats.npts} samples "
+                                f"is overlength by one sample. Dropping last "
+                                f"sample.")
+                    tr.data = tr.data[0:-1]
             length = endtime - starttime
             clip = True
         elif starttime:


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

As identified in #573 - the first sample is sometimes dropped and the starttime is not adjusted leading to one-sample-out errors. I don't know why that was left in and the tests pass if we drop the last sample instead.

### Why was it initiated?  Any relevant Issues?

#573 

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
