### PR TITLE
Detection trim

### DIFF
--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -397,7 +397,8 @@ class Detection(object):
                 pick = [p for p in pick
                         if p.waveform_id.channel_code == channel]
             if len(pick) == 0:
-                Logger.info("No pick for {0}.{1}".format(station, channel))
+                Logger.info(
+                    "No pick for {0}.{1}".format(station, channel))
                 continue
             elif len(pick) > 1:
                 Logger.info(
@@ -406,21 +407,26 @@ class Detection(object):
                 pick.sort(key=lambda p: p.time)
             pick = pick[0]
             cut_start = pick.time - prepick
-            # Find nearest sample to avoid trimming to too-short length - see #573
+            # Find nearest sample to avoid  to too-short length - see #573
             for tr in _st:
-                sample_offset = (cut_start - tr.stats.starttime) / tr.stats.delta
+                sample_offset = (cut_start -
+                                 tr.stats.starttime) / tr.stats.delta
                 sample_offset //= 1
-                # If the sample offset is not a whole number, always take the sample
-                # before that requested
-                _tr_cut_start = tr.stats.starttime + (sample_offset * tr.stats.delta)
+                # If the sample offset is not a whole number, always take the
+                # sample before that requested
+                _tr_cut_start = tr.stats.starttime + (
+                        sample_offset * tr.stats.delta)
                 _tr_cut_end = _tr_cut_start + length
-                Logger.info(f"Trimming {tr.id} between {_tr_cut_end} and {_tr_cut_end}.")
+                Logger.debug(
+                    f"Trimming {tr.id} between {_tr_cut_end} "
+                    f"and {_tr_cut_end}.")
                 _tr = tr.slice(_tr_cut_start, _tr_cut_end).copy()
-                Logger.debug(f"Length: {(_tr.stats.endtime - _tr.stats.starttime)}")
+                Logger.debug(
+                    f"Length: {(_tr.stats.endtime - _tr.stats.starttime)}")
                 Logger.debug(f"Requested length: {length}")
                 if abs((_tr.stats.endtime - _tr.stats.starttime) -
                        length) < tr.stats.delta:
-                    cut_stream += tr
+                    cut_stream += _tr
                 else:
                     Logger.info(
                         "Insufficient data length for {0}".format(tr.id))

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -410,7 +410,9 @@ class Detection(object):
             # Find nearest sample to avoid  to too-short length - see #573
             for tr in _st:
                 sample_offset = (cut_start -
-                                 tr.stats.starttime) / tr.stats.delta
+                                 tr.stats.starttime) * tr.stats.sampling_rate
+                Logger.debug(
+                    f"Sample offset for slice on {tr.id}: {sample_offset}")
                 sample_offset //= 1
                 # If the sample offset is not a whole number, always take the
                 # sample before that requested

--- a/eqcorrscan/core/match_filter/detection.py
+++ b/eqcorrscan/core/match_filter/detection.py
@@ -417,7 +417,7 @@ class Detection(object):
                 # If the sample offset is not a whole number, always take the
                 # sample before that requested
                 _tr_cut_start = tr.stats.starttime + (
-                        sample_offset * tr.stats.delta)
+                    sample_offset * tr.stats.delta)
                 _tr_cut_end = _tr_cut_start + length
                 Logger.debug(
                     f"Trimming {tr.id} between {_tr_cut_end} "

--- a/eqcorrscan/tests/lag_calc_test.py
+++ b/eqcorrscan/tests/lag_calc_test.py
@@ -26,7 +26,6 @@ class SyntheticTests(unittest.TestCase):
     def setUpClass(cls):
         np.random.seed(999)
         print("Setting up class")
-        np.random.seed(999)
         samp_rate = 50
         t_length = .75
         # Make some synthetic templates
@@ -34,6 +33,7 @@ class SyntheticTests(unittest.TestCase):
             nsta=5, ntemplates=5, nseeds=10, samp_rate=samp_rate,
             t_length=t_length, max_amp=10, max_lag=15, phaseout="both",
             jitter=0, noise=False, same_phase=True)
+        print("Made synthetic data")
         # Rename channels
         channel_mapper = {"SYN_Z": "HHZ", "SYN_H": "HHN"}
         for tr in data:
@@ -44,6 +44,7 @@ class SyntheticTests(unittest.TestCase):
         party = Party()
         t = 0
         data_start = data[0].stats.starttime
+        print("Making party")
         for template, template_seeds in zip(templates, seeds):
             template_name = "template_{0}".format(t)
             detections = []
@@ -68,6 +69,8 @@ class SyntheticTests(unittest.TestCase):
             family = Family(template=_template, detections=detections)
             party += family
             t += 1
+            print(f"Made template {template_name}")
+        print("Made party")
         cls.party = party
         cls.data = data
         cls.t_length = t_length


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

As noted in #573 - lag-calc fails to run sometimes when slicing to particular lengths. This happens when the pick.time - pre_pick does not fall on a sample. Obspy will often slice to give a shorter window than needed. This PR now slices starting at the nearest sample before the pick.time - pre_pick to ensure that data are trimmed to within one sample of the requested length.

### Why was it initiated?  Any relevant Issues?

#573 

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [x] All tests still pass.
- [x] Any new features or fixed regressions are be covered via new tests.
- [x] Any new or changed features have are fully documented.
- [x] Significant changes have been added to `CHANGES.md`.
- [x] First time contributors have added your name to `CONTRIBUTORS.md`.
