### PR TITLE
Always get new catalog from detections #598

### DIFF
--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -45,16 +45,13 @@ class Family(object):
         if isinstance(detections, Detection):
             detections = [detections]
         self.detections = detections or []
-        self.__catalog = get_catalog(self.detections)
         if catalog:
             Logger.warning("Setting catalog directly is no-longer supported, "
                            "now generated from detections.")
 
     @property
     def catalog(self):
-        if len(self.__catalog) != len(self.detections):
-            self.__catalog = get_catalog(self.detections)
-        return self.__catalog
+        return get_catalog(self.detections)
 
     @catalog.setter
     def catalog(self, catalog):

--- a/eqcorrscan/core/match_filter/family.py
+++ b/eqcorrscan/core/match_filter/family.py
@@ -148,13 +148,11 @@ class Family(object):
         if isinstance(other, Family):
             if other.template == self.template:
                 self.detections.extend(other.detections)
-                self.__catalog.events.extend(get_catalog(other.detections))
             else:
                 raise NotImplementedError('Templates do not match')
         elif isinstance(other, Detection) and other.template_name \
                 == self.template.name:
             self.detections.append(other)
-            self.__catalog.events.extend(get_catalog([other]))
         elif isinstance(other, Detection):
             raise NotImplementedError('Templates do not match')
         else:


### PR DESCRIPTION
<!--
Thank your for contributing to EQcorrscan!
Please fill out the sections below.
-->

### What does this PR do?

Makes `Family.catalog` always get a fresh view of the events associated with detections.

### Why was it initiated?  Any relevant Issues?

#598 

### PR Checklist
- [x] `develop` base branch selected?
- [x] This PR is not directly related to an existing issue (which has no PR yet).
- [ ] All tests still pass.
~~- [ ] Any new features or fixed regressions are be covered via new tests.~~
- [x] Any new or changed features have are fully documented.
~~- [ ] Significant changes have been added to `CHANGES.md`.~~
~~- [ ] First time contributors have added your name to `CONTRIBUTORS.md`.~~
