### PR TITLE
Fix integer-overflow in decluster type dispatch (#546)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,9 @@
   - More stable extraction of data for correlation
 - utils.findpeaks
   - Added pick-time declustering.
+  - Fix integer-overflow in `decluster`/`decluster_distance_time` where a large
+    `index.max()` could be silently downgraded to a 32-bit `c_long` routine by a
+    small `trig_int`, corrupting declustering on 32-bit-long platforms (#546).
 - utils.correlate
   - Added option to produce "cc-squared" (cc * abs(cc)) detection statistic
 

--- a/eqcorrscan/tests/find_peaks_test.py
+++ b/eqcorrscan/tests/find_peaks_test.py
@@ -12,10 +12,13 @@ import warnings
 from obspy import read_events
 from obspy.core.event import Catalog, Event, Origin
 
+import types
+
 from eqcorrscan.utils.findpeaks import (
     find_peaks2_short, coin_trig, multi_find_peaks, find_peaks_compiled,
     _find_peaks_c, decluster, decluster_distance_time, decluster_pick_times,
-    average_pick_time_diff_matrix, get_det_val)
+    average_pick_time_diff_matrix, get_det_val, _get_func_and_type)
+from eqcorrscan.utils import findpeaks
 from eqcorrscan.utils.timer import time_func
 
 
@@ -155,6 +158,57 @@ class TestDeclustering:
             peaks, index, trig_int, catalog, hypocentral_separation,
             threshold=0)
         assert len(peaks) == len(peaks_out)
+
+    def test_dispatch_picks_widest_type(self, monkeypatch):
+        """Regression test for issue #546.
+
+        The integer type / C-routine selection must use a type wide enough
+        for *every* value (notably ``index.max()``), not just whichever
+        value happens to be checked last. Previously a large ``index.max()``
+        followed by a small ``trig_int`` selected the narrow ``c_long``
+        routine, so on platforms where ``c_long`` is 32-bit (e.g. Windows)
+        the index array was truncated and declustering produced corrupt
+        results.
+
+        This is checked independently of the host platform by injecting a
+        32-bit ``c_long`` and a 64-bit ``c_longlong`` (the Windows layout),
+        so the regression is exercised even where ``c_long`` is natively
+        64-bit.
+        """
+        def make_int(bits):
+            """A minimal ctypes-int stand-in doing signed `bits`-wide wrap."""
+            class _CInt:
+                def __init__(self, v):
+                    v = int(v)
+                    self.value = ((v + (1 << (bits - 1))) % (1 << bits)
+                                  ) - (1 << (bits - 1))
+            return _CInt
+
+        fake_ctypes = types.SimpleNamespace(
+            c_long=make_int(32), c_longlong=make_int(64))
+        monkeypatch.setattr(findpeaks, "ctypes", fake_ctypes)
+
+        utilslib = types.SimpleNamespace(
+            decluster="long", decluster_ll="longlong")
+
+        # Small values fit the narrow (c_long) type.
+        _, func = _get_func_and_type(utilslib, (2000, 100), "decluster")
+        assert func == "long"
+
+        # Large index.max() (> 2**31) with a small trig_int checked last must
+        # still select the wide (longlong) routine -- the bug in #546.
+        _, func = _get_func_and_type(
+            utilslib, (5 * 10 ** 13, 100), "decluster")
+        assert func == "longlong"
+
+        # Order independence: small value first, large value last.
+        _, func = _get_func_and_type(
+            utilslib, (100, 5 * 10 ** 13), "decluster")
+        assert func == "longlong"
+
+        # Beyond 64-bit overflows even longlong.
+        with pytest.raises(OverflowError):
+            _get_func_and_type(utilslib, (2 ** 100, 1), "decluster")
 
 
 class TestStandardPeakFinding:

--- a/eqcorrscan/utils/findpeaks.py
+++ b/eqcorrscan/utils/findpeaks.py
@@ -251,6 +251,38 @@ def multi_find_peaks(arr, thresh, trig_int, parallel=True, full_peaks=False,
     return peaks
 
 
+def _get_func_and_type(utilslib, values, base_name):
+    """Select a C routine and integer type wide enough for *all* values.
+
+    Returns the narrowest available integer type -- ``ctypes.c_long`` and
+    then ``ctypes.c_longlong`` -- that can represent every value in *values*
+    without overflow, together with the matching routine on *utilslib*
+    (``base_name`` for ``c_long`` or ``base_name + "_ll"`` for
+    ``c_longlong``).
+
+    The previous implementation looped over the values and let the *last*
+    one decide the type, so a large ``index.max()`` could be silently
+    downgraded back to ``c_long`` by a small ``trig_int`` that happened to
+    be checked last. On platforms where ``c_long`` is 32-bit (e.g. Windows)
+    this truncated the index array and produced corrupt declustering
+    results (see GitHub issue #546).
+
+    :type utilslib: ctypes.CDLL
+    :param utilslib: Loaded EQcorrscan C library.
+    :type values: iterable of int
+    :param values: Integer values that must fit in the chosen type.
+    :type base_name: str
+    :param base_name: Name of the ``c_long`` routine on *utilslib*; the
+        ``c_longlong`` variant is assumed to be ``base_name + "_ll"``.
+
+    :return: tuple of (integer ctype, C routine)
+    """
+    for long_type, suffix in ((ctypes.c_long, ""), (ctypes.c_longlong, "_ll")):
+        if all(val == long_type(val).value for val in values):
+            return long_type, getattr(utilslib, base_name + suffix)
+    raise OverflowError("Maximum index larger than internal long long")
+
+
 def decluster_distance_time(peaks, index, trig_int, catalog,
                             hypocentral_separation, threshold=0,
                             num_threads=None):
@@ -286,15 +318,8 @@ def decluster_distance_time(peaks, index, trig_int, catalog,
     length = peaks.shape[0]
     trig_int = int(trig_int)
 
-    for var in [index.max(), trig_int]:
-        if var == ctypes.c_long(var).value:
-            long_type = ctypes.c_long
-            func = utilslib.decluster_dist_time
-        elif var == ctypes.c_longlong(var).value:
-            long_type = ctypes.c_longlong
-            func = utilslib.decluster_dist_time_ll
-        else:
-            raise OverflowError("Maximum index larger than internal long long")
+    long_type, func = _get_func_and_type(
+        utilslib, (index.max(), trig_int), "decluster_dist_time")
 
     func.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length,),
@@ -351,15 +376,8 @@ def decluster(peaks, index, trig_int, threshold=0):
     length = peaks.shape[0]
     trig_int = int(trig_int)
 
-    for var in [index.max(), trig_int]:
-        if var == ctypes.c_long(var).value:
-            long_type = ctypes.c_long
-            func = utilslib.decluster
-        elif var == ctypes.c_longlong(var).value:
-            long_type = ctypes.c_longlong
-            func = utilslib.decluster_ll
-        else:
-            raise OverflowError("Maximum index larger than internal long long")
+    long_type, func = _get_func_and_type(
+        utilslib, (index.max(), trig_int), "decluster")
 
     func.argtypes = [
         np.ctypeslib.ndpointer(dtype=np.float32, shape=(length,),


### PR DESCRIPTION
## What does this PR do?

Fixes the unreported integer-overflow in `decluster` / `decluster_distance_time` reported in #546.

Both functions selected the ctypes integer type and the matching C routine with this loop:

```python
for var in [index.max(), trig_int]:
    if var == ctypes.c_long(var).value:
        long_type = ctypes.c_long;     func = utilslib.decluster
    elif var == ctypes.c_longlong(var).value:
        long_type = ctypes.c_longlong; func = utilslib.decluster_ll
    else:
        raise OverflowError(...)
```

The loop has no `break`, so the **last** value (`trig_int`) decides the type. When `index.max()` is large enough to need `c_longlong` (e.g. multiple days of samples) but the trailing `trig_int` fits in `c_long`, the choice made for `index.max()` is overwritten and the **narrow** `c_long` routine is used.

On platforms where `c_long` is 32-bit (e.g. Windows, which is where #546 was reported), the index array is then cast to 32-bit and truncated, corrupting the declustering and producing the reported `IndexError: index 0 is out of bounds for axis 0 with size 0` downstream.

## Reproduction

Modelling the Windows layout (`c_long` = 32-bit, `c_longlong` = 64-bit), the old dispatch on a large index with a small trigger interval:

```
index.max() = 5e13, trig_int = 100
OLD picks: c_long / decluster     <-- wrong: 5e13 overflows a 32-bit long
index.max() truncated to 32-bit: -2009260032  (should be 50000000000000)
```

The existing `*_longlong` tests don't catch this because they scale **both** `index` and `trig_int` by `1e10`, so the trailing `trig_int` is also large and the last iteration happens to pick `longlong` too.

## Fix

Select the narrowest integer type wide enough for **every** value, via a small `_get_func_and_type` helper used by both functions. Behaviour is unchanged on 64-bit-`long` platforms and in the both-values-large case; only the previously-broken large-index/small-trig case now correctly dispatches to the `_ll` routine.

## Tests

Added `test_dispatch_picks_widest_type`, a platform-independent regression test that injects a 32-bit `c_long` / 64-bit `c_longlong` layout so the regression is exercised even where `c_long` is natively 64-bit. It fails against the old last-iteration-wins logic and passes with the fix. (The compiled `libutils` is not required for this test.)